### PR TITLE
release: Phase 2C + Phase 8A → main

### DIFF
--- a/backend/alembic/versions/20250222_0000_0003_pipeline_templates.py
+++ b/backend/alembic/versions/20250222_0000_0003_pipeline_templates.py
@@ -1,0 +1,54 @@
+"""pipeline templates
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2025-02-22 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create pipeline_templates table."""
+    op.create_table(
+        "pipeline_templates",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("graph_data", sa.JSON(), nullable=False),
+        sa.Column("design_data", sa.JSON(), nullable=False),
+        sa.Column("is_public", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_pipeline_templates_user_id", "pipeline_templates", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop pipeline_templates table."""
+    op.drop_index("ix_pipeline_templates_user_id", table_name="pipeline_templates")
+    op.drop_table("pipeline_templates")

--- a/backend/gateway/main.py
+++ b/backend/gateway/main.py
@@ -11,7 +11,7 @@ from backend.shared.database import init_db
 from backend.shared.schemas import HealthResponse
 
 from .rate_limiter import close_redis, init_redis
-from .routes import api_keys, auth, chat, conversations, pipeline
+from .routes import api_keys, auth, chat, conversations, pipeline, templates
 
 
 @asynccontextmanager
@@ -48,6 +48,7 @@ app.include_router(chat.router, prefix="/api/v1", tags=["chat"])
 app.include_router(conversations.router, prefix="/api/v1", tags=["conversations"])
 app.include_router(pipeline.router, prefix="/api/v1", tags=["pipelines"])
 app.include_router(api_keys.router, prefix="/api/v1", tags=["api-keys"])
+app.include_router(templates.router, prefix="/api/v1", tags=["templates"])
 
 
 @app.get("/api/v1/health", response_model=HealthResponse)

--- a/backend/gateway/routes/pipeline.py
+++ b/backend/gateway/routes/pipeline.py
@@ -48,15 +48,13 @@ class PipelineStatusResponse(BaseModel):
     result: PipelineResult | None = None
 
 
-@router.post("/pipelines/execute", response_model=PipelineStatusResponse)
-async def execute_pipeline(
-    request: PipelineExecuteRequest,
-    current_user: User = Depends(get_current_user),
+async def _execute_pipeline_core(
+    design: DesignProposal,
+    current_user: User,
 ) -> PipelineStatusResponse:
-    """Execute a pipeline from a design proposal.
+    """Core pipeline execution logic shared by execute and execute-direct.
 
-    Requires authentication. Currently runs synchronously.
-    Phase 7 will add background execution.
+    Handles budget check, pipeline lock, orchestrator execution, and cost recording.
     """
     pipeline_id = str(uuid.uuid4())
     started_at = datetime.now(timezone.utc).isoformat()
@@ -68,7 +66,7 @@ async def execute_pipeline(
     _pipeline_runs[pipeline_id] = {
         "user_id": str(current_user.id),
         "status": "running",
-        "design_name": request.design.name,
+        "design_name": design.name,
         "started_at": started_at,
         "result": None,
     }
@@ -94,7 +92,7 @@ async def execute_pipeline(
     orchestrator = PipelineOrchestrator()
 
     try:
-        result = await orchestrator.execute(design=request.design)
+        result = await orchestrator.execute(design=design)
         _pipeline_runs[pipeline_id]["status"] = result.status
         _pipeline_runs[pipeline_id]["result"] = result
         # Record cost
@@ -104,7 +102,7 @@ async def execute_pipeline(
         logger.error(f"Pipeline execution failed: {e}", exc_info=True)
         _pipeline_runs[pipeline_id]["status"] = "failed"
         result = PipelineResult(
-            design_name=request.design.name,
+            design_name=design.name,
             status="failed",
             error="Pipeline execution failed. Please try again.",
         )
@@ -115,10 +113,36 @@ async def execute_pipeline(
     return PipelineStatusResponse(
         pipeline_id=pipeline_id,
         status=result.status,
-        design_name=request.design.name,
+        design_name=design.name,
         started_at=started_at,
         result=result,
     )
+
+
+@router.post("/pipelines/execute", response_model=PipelineStatusResponse)
+async def execute_pipeline(
+    request: PipelineExecuteRequest,
+    current_user: User = Depends(get_current_user),
+) -> PipelineStatusResponse:
+    """Execute a pipeline from a design proposal.
+
+    Requires authentication. Currently runs synchronously.
+    Phase 7 will add background execution.
+    """
+    return await _execute_pipeline_core(request.design, current_user)
+
+
+@router.post("/pipelines/execute-direct", response_model=PipelineStatusResponse)
+async def execute_direct(
+    request: PipelineExecuteRequest,
+    current_user: User = Depends(get_current_user),
+) -> PipelineStatusResponse:
+    """Execute a pipeline directly from the visual editor.
+
+    Bypasses the discussion engine. Same cost/lock checks apply.
+    Future: may add editor-specific features (e.g., step-by-step execution).
+    """
+    return await _execute_pipeline_core(request.design, current_user)
 
 
 def _get_user_pipeline(pipeline_id: str, user_id: str) -> dict:

--- a/backend/gateway/routes/templates.py
+++ b/backend/gateway/routes/templates.py
@@ -1,0 +1,133 @@
+"""Pipeline template CRUD API routes."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.gateway.auth import get_current_user
+from backend.shared.database import get_db
+from backend.shared.models import PipelineTemplate, User
+from backend.shared.schemas import (
+    TemplateCreate,
+    TemplateListResponse,
+    TemplateResponse,
+    TemplateUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+MAX_TEMPLATES_PER_USER = 50
+
+
+def _get_owned_template_query(template_id: uuid.UUID, user_id: uuid.UUID):
+    """Build a query for a template owned by the given user."""
+    return select(PipelineTemplate).where(
+        PipelineTemplate.id == template_id,
+        PipelineTemplate.user_id == user_id,
+    )
+
+
+@router.post("/templates", response_model=TemplateResponse, status_code=201)
+async def create_template(
+    body: TemplateCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PipelineTemplate:
+    """Create a new pipeline template."""
+    # Check per-user limit (soft limit; concurrent requests may slightly exceed)
+    count_result = await db.execute(
+        select(func.count()).where(PipelineTemplate.user_id == current_user.id)
+    )
+    count = count_result.scalar_one()
+    if count >= MAX_TEMPLATES_PER_USER:
+        limit = MAX_TEMPLATES_PER_USER
+        raise HTTPException(
+            status_code=400,
+            detail=f"Template limit reached ({limit}). Delete some first.",
+        )
+
+    template = PipelineTemplate(
+        id=uuid.uuid4(),
+        user_id=current_user.id,
+        name=body.name,
+        description=body.description or None,
+        graph_data=body.graph_data,
+        design_data=body.design_data,
+    )
+    db.add(template)
+    await db.flush()
+    await db.refresh(template)
+    return template
+
+
+@router.get("/templates", response_model=list[TemplateListResponse])
+async def list_templates(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[PipelineTemplate]:
+    """List the current user's pipeline templates."""
+    result = await db.execute(
+        select(PipelineTemplate)
+        .where(PipelineTemplate.user_id == current_user.id)
+        .order_by(PipelineTemplate.updated_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+@router.get("/templates/{template_id}", response_model=TemplateResponse)
+async def get_template(
+    template_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PipelineTemplate:
+    """Get a specific pipeline template (owner only)."""
+    result = await db.execute(_get_owned_template_query(template_id, current_user.id))
+    template = result.scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return template
+
+
+@router.put("/templates/{template_id}", response_model=TemplateResponse)
+async def update_template(
+    template_id: uuid.UUID,
+    body: TemplateUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PipelineTemplate:
+    """Update a pipeline template (owner only)."""
+    result = await db.execute(_get_owned_template_query(template_id, current_user.id))
+    template = result.scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(template, field, value)
+
+    await db.flush()
+    await db.refresh(template)
+    return template
+
+
+@router.delete("/templates/{template_id}")
+async def delete_template(
+    template_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Delete a pipeline template (owner only)."""
+    result = await db.execute(_get_owned_template_query(template_id, current_user.id))
+    template = result.scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    await db.delete(template)
+    return Response(status_code=204)

--- a/backend/shared/models.py
+++ b/backend/shared/models.py
@@ -72,6 +72,9 @@ class User(Base):
     api_keys: Mapped[list["APIKey"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
+    templates: Mapped[list["PipelineTemplate"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class Conversation(Base):
@@ -141,6 +144,33 @@ class APIKey(Base):
 
     # Relationships
     user: Mapped["User"] = relationship(back_populates="api_keys")
+
+
+class PipelineTemplate(Base):
+    """Saved pipeline template for the visual editor."""
+
+    __tablename__ = "pipeline_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    graph_data: Mapped[dict] = mapped_column(JSON, nullable=False)
+    design_data: Mapped[dict] = mapped_column(JSON, nullable=False)
+    is_public: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )  # Phase 8B: shared templates
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    # Relationships
+    user: Mapped["User"] = relationship(back_populates="templates")
 
 
 class UserDailyCost(Base):

--- a/backend/shared/schemas.py
+++ b/backend/shared/schemas.py
@@ -1,11 +1,14 @@
 """Pydantic schemas for request/response validation."""
 
+import json
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from .models import ConversationStatus, MessageRole, UserRole
+
+MAX_JSON_SIZE_BYTES = 512 * 1024  # 512KB
 
 
 # User schemas
@@ -140,6 +143,97 @@ class UsageResponse(BaseModel):
     daily_limit: float
     remaining: float
     is_unlimited: bool
+
+
+# Pipeline Template schemas
+def _check_json_size(v: dict, field_name: str) -> dict:
+    """Validate JSON dict does not exceed 512KB when serialized."""
+
+    size = len(json.dumps(v, default=str).encode())
+    if size > MAX_JSON_SIZE_BYTES:
+        max_kb = MAX_JSON_SIZE_BYTES // 1024
+        raise ValueError(f"{field_name} exceeds {max_kb}KB limit")
+    return v
+
+
+class TemplateCreate(BaseModel):
+    """Schema for creating a pipeline template."""
+
+    name: str = Field(min_length=1, max_length=255)
+    description: str = ""
+    graph_data: dict
+    design_data: dict
+
+    @field_validator("graph_data")
+    @classmethod
+    def validate_graph_data_size(cls, v: dict) -> dict:
+        """Ensure graph_data does not exceed size limit."""
+        return _check_json_size(v, "graph_data")
+
+    @field_validator("design_data")
+    @classmethod
+    def validate_design_data_size(cls, v: dict) -> dict:
+        """Ensure design_data does not exceed size limit."""
+        return _check_json_size(v, "design_data")
+
+
+class TemplateUpdate(BaseModel):
+    """Schema for updating a pipeline template."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    graph_data: dict | None = None
+    design_data: dict | None = None
+
+    @field_validator("graph_data")
+    @classmethod
+    def validate_graph_data_size(cls, v: dict | None) -> dict | None:
+        """Ensure graph_data does not exceed size limit."""
+        if v is not None:
+            return _check_json_size(v, "graph_data")
+        return v
+
+    @field_validator("design_data")
+    @classmethod
+    def validate_design_data_size(cls, v: dict | None) -> dict | None:
+        """Ensure design_data does not exceed size limit."""
+        if v is not None:
+            return _check_json_size(v, "design_data")
+        return v
+
+
+class TemplateResponse(BaseModel):
+    """Schema for pipeline template response."""
+
+    id: uuid.UUID
+    name: str
+    description: str | None
+    graph_data: dict
+    design_data: dict
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        """Pydantic config."""
+
+        from_attributes = True
+
+
+class TemplateListResponse(BaseModel):
+    """Schema for pipeline template list response (summary)."""
+
+    id: uuid.UUID
+    name: str
+    description: str | None
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        """Pydantic config."""
+
+        from_attributes = True
 
 
 # Health check schema

--- a/docs/phase-08a-react-flow-editor.md
+++ b/docs/phase-08a-react-flow-editor.md
@@ -1,0 +1,66 @@
+# Phase 8A: React Flow Pipeline Editor + Split View
+
+## 개요
+
+React Flow 기반 시각적 파이프라인 에디터를 추가하여 사용자가 에이전트 파이프라인을 시각적으로 설계하고 실행할 수 있게 합니다.
+
+## 구현 범위
+
+### 백엔드
+- **PipelineTemplate 모델**: 파이프라인 템플릿 저장을 위한 DB 모델 + Alembic 마이그레이션
+- **Template CRUD API**: 생성/조회/수정/삭제 엔드포인트 (소유권 검증, 50개 한도)
+- **execute-direct 엔드포인트**: 토론 엔진을 건너뛰고 에디터에서 직접 파이프라인 실행
+
+### 프론트엔드
+- **SplitView**: 리사이즈 가능한 분할 패널 (좌: 채팅, 우: 에디터)
+- **PipelineEditor**: React Flow 래퍼 컴포넌트
+- **AgentNode**: 커스텀 노드 (이름, 역할, 모델, 상태 표시)
+- **Toolbar**: Add Node, Run, Save, Load, Clear 버튼
+- **PropertyPanel**: 선택한 노드의 속성 편집 사이드바
+- **TemplateListPanel**: 템플릿 저장/불러오기 모달
+- **flowToDesign**: React Flow 그래프 → DesignProposal 변환 (위상 정렬)
+- **designToFlow**: DesignProposal → React Flow 그래프 변환 (자동 레이아웃)
+- **usePipelineExecution**: 실행 상태 추적 훅
+- **useTemplates**: Template CRUD API 훅
+
+## API 명세
+
+### Template API
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| `POST` | `/api/v1/templates` | 템플릿 생성 |
+| `GET` | `/api/v1/templates` | 사용자 템플릿 목록 |
+| `GET` | `/api/v1/templates/{id}` | 템플릿 상세 |
+| `PUT` | `/api/v1/templates/{id}` | 템플릿 수정 |
+| `DELETE` | `/api/v1/templates/{id}` | 템플릿 삭제 |
+
+### Pipeline API (추가)
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| `POST` | `/api/v1/pipelines/execute-direct` | 에디터에서 직접 실행 |
+
+## 보안
+
+- 템플릿 소유권 검증: `user_id == current_user.id` (IDOR 방지, 404 통일)
+- 사용자당 최대 50개 템플릿 제한
+- 직접 실행도 기존 `check_budget()` / `acquire_pipeline_lock()` / `record_cost()` 경로 동일
+
+## 테스트 결과
+
+- `test_templates.py`: Template CRUD + 소유권 검증 + 유효성 검증
+- `test_direct_execute.py`: 직접 실행 + 비용 확인 + 기존 API와의 로직 공유 검증
+
+## 알려진 제한사항
+
+- React Flow v11 사용 (v12는 React 19 필요, 프로젝트는 React 18.3.1)
+- 동시 편집 미지원 (last-write-wins + `updated_at`)
+- 프론트엔드는 TypeScript 컴파일 + ESLint로 검증 (런타임 테스트 없음)
+
+## 다음 단계 (Phase 8B)
+
+- 병렬 실행 (LangGraph `Send()` fan-out/fan-in)
+- 조건부 엣지 (필드-연산자-값 비교)
+- 커스텀 에이전트 노드 (사용자 정의 프롬프트/설정)
+- 템플릿 공유 (공개 템플릿 + 복제)

--- a/frontend/app/components/SplitView.tsx
+++ b/frontend/app/components/SplitView.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SplitViewProps {
+  left: React.ReactNode;
+  right: React.ReactNode;
+  isEditorOpen: boolean;
+  onEditorToggle: (open: boolean) => void;
+}
+
+const MIN_PANEL_WIDTH = 300;
+const STORAGE_KEY = "agentforge-split-view";
+
+export default function SplitView({ left, right, isEditorOpen, onEditorToggle }: SplitViewProps) {
+  const [splitRatio, setSplitRatio] = useState(0.5);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+
+  // Restore splitRatio from localStorage
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        if (typeof parsed.ratio === "number") setSplitRatio(parsed.ratio);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  // Save splitRatio
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ratio: splitRatio }));
+    } catch {
+      // Ignore storage errors
+    }
+  }, [splitRatio]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const ratio = Math.max(
+        MIN_PANEL_WIDTH / rect.width,
+        Math.min(1 - MIN_PANEL_WIDTH / rect.width, x / rect.width)
+      );
+      setSplitRatio(ratio);
+    };
+
+    const handleMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="h-full flex relative">
+      {/* Left panel (Chat) */}
+      <div
+        className="h-full overflow-hidden"
+        style={{ width: isEditorOpen ? `${splitRatio * 100}%` : "100%" }}
+      >
+        {left}
+      </div>
+
+      {isEditorOpen && (
+        <>
+          {/* Resize handle */}
+          <div
+            onMouseDown={handleMouseDown}
+            className="w-1.5 bg-gray-800 hover:bg-primary-600 cursor-col-resize flex-shrink-0 transition-colors relative group"
+          >
+            <div className="absolute inset-y-0 -left-1 -right-1" />
+          </div>
+
+          {/* Right panel (Editor) */}
+          <div
+            className="h-full overflow-hidden"
+            style={{ width: `${(1 - splitRatio) * 100}%` }}
+          >
+            {right}
+          </div>
+        </>
+      )}
+
+      {/* Toggle button */}
+      <button
+        onClick={() => onEditorToggle(!isEditorOpen)}
+        className="absolute top-2 right-2 z-30 px-2.5 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs rounded border border-gray-600 transition-colors"
+        title={isEditorOpen ? "Close Editor" : "Open Pipeline Editor"}
+      >
+        {isEditorOpen ? "Close Editor" : "Pipeline Editor"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/components/pipeline-editor/PipelineEditor.tsx
+++ b/frontend/app/components/pipeline-editor/PipelineEditor.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+} from "reactflow";
+import "reactflow/dist/style.css";
+
+import { nodeTypes } from "./nodes/AgentNodeTypes";
+import { useFlowState } from "./hooks/useFlowState";
+import { usePipelineExecution } from "./hooks/usePipelineExecution";
+import { useTemplates } from "./hooks/useTemplates";
+import { flowToDesign } from "./utils/flowToDesign";
+import { designToFlow } from "./utils/designToFlow";
+import type { AgentNodeData } from "./nodes/AgentNode";
+
+import Toolbar from "./panels/Toolbar";
+import PropertyPanel from "./panels/PropertyPanel";
+import TemplateListPanel from "./panels/TemplateListPanel";
+
+interface PipelineEditorProps {
+  onError?: (message: string) => void;
+  onEditorReady?: (loadDesign: (design: Record<string, unknown>) => void) => void;
+}
+
+export default function PipelineEditor({ onError, onEditorReady }: PipelineEditorProps) {
+  const {
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+    selectedNode,
+    setSelectedNodeId,
+    onNodesChange,
+    onEdgesChange,
+    onConnect,
+    addNode,
+    updateNodeData,
+    deleteNode,
+    clearAll,
+    setAllNodesStatus,
+  } = useFlowState();
+
+  const [templateMode, setTemplateMode] = useState<"save" | "load" | null>(
+    null
+  );
+
+  const {
+    templates,
+    loading: templatesLoading,
+    fetchTemplates,
+    loadTemplate,
+    saveTemplate,
+    deleteTemplate,
+  } = useTemplates();
+
+  const nodeNameToIdMap = useCallback(() => {
+    const map = new Map<string, string>();
+    for (const node of nodes) {
+      map.set(node.data.name, node.id);
+    }
+    return map;
+  }, [nodes]);
+
+  const updateNodeStatus = useCallback(
+    (nodeId: string, status: AgentNodeData["status"]) => {
+      updateNodeData(nodeId, { status });
+    },
+    [updateNodeData]
+  );
+
+  const { isRunning, executeFromEditor } = usePipelineExecution(
+    updateNodeStatus,
+    setAllNodesStatus,
+    nodeNameToIdMap
+  );
+
+  const handleRun = useCallback(async () => {
+    try {
+      const design = flowToDesign(nodes, edges);
+      await executeFromEditor(design);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Pipeline execution failed";
+      onError?.(msg);
+    }
+  }, [nodes, edges, executeFromEditor, onError]);
+
+  const handleSaveTemplate = useCallback(
+    async (name: string, description: string) => {
+      try {
+        const design = flowToDesign(nodes, edges);
+        await saveTemplate({
+          name,
+          description,
+          graph_data: {
+            nodes: nodes.map((n) => ({
+              id: n.id,
+              type: n.type,
+              position: n.position,
+              data: n.data,
+            })),
+            edges: edges.map((e) => ({
+              id: e.id,
+              source: e.source,
+              target: e.target,
+            })),
+          },
+          design_data: design as unknown as Record<string, unknown>,
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : "Failed to save template";
+        onError?.(msg);
+      }
+    },
+    [nodes, edges, saveTemplate, onError]
+  );
+
+  const handleLoadTemplate = useCallback(
+    async (id: string) => {
+      const template = await loadTemplate(id);
+      if (!template) {
+        onError?.("Failed to load template");
+        return;
+      }
+
+      const graphData = template.graph_data;
+      if (graphData?.nodes && Array.isArray(graphData.nodes) && graphData?.edges && Array.isArray(graphData.edges)) {
+        setNodes(
+          (graphData.nodes as Node<AgentNodeData>[]).map((n) => ({
+            ...n,
+            data: { ...n.data, status: "idle" as const },
+          }))
+        );
+        setEdges(graphData.edges as Edge[]);
+      } else if (template.design_data) {
+        const design = template.design_data as {
+          name: string;
+          description: string;
+          agents: { name: string; role: string; llm_model: string; description: string }[];
+        };
+        const { nodes: newNodes, edges: newEdges } = designToFlow(design);
+        setNodes(newNodes);
+        setEdges(newEdges);
+      }
+    },
+    [loadTemplate, setNodes, setEdges, onError]
+  );
+
+  // Load design from chat (called externally)
+  const loadDesign = useCallback(
+    (design: { name: string; description: string; agents: { name: string; role: string; llm_model: string; description: string }[] }) => {
+      const { nodes: newNodes, edges: newEdges } = designToFlow(design);
+      setNodes(newNodes);
+      setEdges(newEdges);
+    },
+    [setNodes, setEdges]
+  );
+
+  const onNodeClick = useCallback(
+    (_: React.MouseEvent, node: Node) => {
+      setSelectedNodeId(node.id);
+    },
+    [setSelectedNodeId]
+  );
+
+  const onPaneClick = useCallback(() => {
+    setSelectedNodeId(null);
+  }, [setSelectedNodeId]);
+
+  // Expose loadDesign to parent via callback
+  useEffect(() => {
+    onEditorReady?.((design: Record<string, unknown>) => {
+      loadDesign(design as Parameters<typeof loadDesign>[0]);
+    });
+  }, [loadDesign, onEditorReady]);
+
+  const miniMapNodeColor = useMemo(
+    () => (node: Node) => {
+      const data = node.data as AgentNodeData;
+      if (data.status === "running") return "#3b82f6";
+      if (data.status === "completed") return "#10b981";
+      if (data.status === "failed") return "#ef4444";
+      return "#6b7280";
+    },
+    []
+  );
+
+  return (
+    <div className="h-full flex flex-col relative">
+      <Toolbar
+        onAddNode={addNode}
+        onRun={handleRun}
+        onSave={() => setTemplateMode("save")}
+        onLoad={() => setTemplateMode("load")}
+        onClear={clearAll}
+        isRunning={isRunning}
+        nodeCount={nodes.length}
+      />
+
+      <div className="flex-1 relative">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onNodeClick={onNodeClick}
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          fitView
+          className="bg-gray-950"
+          defaultEdgeOptions={{ animated: true }}
+        >
+          <Background color="#374151" gap={20} />
+          <Controls className="!bg-gray-800 !border-gray-600 !shadow-lg [&>button]:!bg-gray-700 [&>button]:!border-gray-600 [&>button]:!text-gray-300 [&>button:hover]:!bg-gray-600" />
+          <MiniMap
+            nodeColor={miniMapNodeColor}
+            className="!bg-gray-900 !border-gray-700"
+            maskColor="rgba(0, 0, 0, 0.6)"
+          />
+        </ReactFlow>
+
+        <PropertyPanel
+          node={selectedNode}
+          onUpdate={updateNodeData}
+          onDelete={(id) => {
+            deleteNode(id);
+            setSelectedNodeId(null);
+          }}
+          onClose={() => setSelectedNodeId(null)}
+        />
+      </div>
+
+      {templateMode && (
+        <TemplateListPanel
+          mode={templateMode}
+          templates={templates}
+          loading={templatesLoading}
+          onClose={() => setTemplateMode(null)}
+          onSave={handleSaveTemplate}
+          onLoad={handleLoadTemplate}
+          onDelete={deleteTemplate}
+          onRefresh={fetchTemplates}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/pipeline-editor/hooks/useFlowState.ts
+++ b/frontend/app/components/pipeline-editor/hooks/useFlowState.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+} from "reactflow";
+import type { AgentNodeData } from "../nodes/AgentNode";
+import { getRoleConfig } from "../utils/nodeDefaults";
+
+function nextNodeId(): string {
+  return `agent-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function useFlowState() {
+  const [nodes, setNodes] = useState<Node<AgentNodeData>[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    []
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    []
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    []
+  );
+
+  const addNode = useCallback(
+    (role: string) => {
+      const config = getRoleConfig(role);
+      const id = nextNodeId();
+      const newNode: Node<AgentNodeData> = {
+        id,
+        type: "agentNode",
+        position: {
+          x: 250 + Math.random() * 100,
+          y: nodes.length * 150 + 50,
+        },
+        data: {
+          name: `${config.label}_${id.split("-")[1]}`,
+          role,
+          llmModel: config.defaultModel,
+          description: "",
+          status: "idle",
+        },
+      };
+      setNodes((nds) => [...nds, newNode]);
+    },
+    [nodes.length]
+  );
+
+  const updateNodeData = useCallback(
+    (nodeId: string, data: Partial<AgentNodeData>) => {
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === nodeId ? { ...n, data: { ...n.data, ...data } } : n
+        )
+      );
+    },
+    []
+  );
+
+  const deleteNode = useCallback(
+    (nodeId: string) => {
+      setNodes((nds) => nds.filter((n) => n.id !== nodeId));
+      setEdges((eds) =>
+        eds.filter((e) => e.source !== nodeId && e.target !== nodeId)
+      );
+      if (selectedNodeId === nodeId) {
+        setSelectedNodeId(null);
+      }
+    },
+    [selectedNodeId]
+  );
+
+  const clearAll = useCallback(() => {
+    setNodes([]);
+    setEdges([]);
+    setSelectedNodeId(null);
+  }, []);
+
+  const setAllNodesStatus = useCallback(
+    (status: AgentNodeData["status"]) => {
+      setNodes((nds) =>
+        nds.map((n) => ({ ...n, data: { ...n.data, status } }))
+      );
+    },
+    []
+  );
+
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId) || null;
+
+  return {
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+    selectedNodeId,
+    selectedNode,
+    setSelectedNodeId,
+    onNodesChange,
+    onEdgesChange,
+    onConnect,
+    addNode,
+    updateNodeData,
+    deleteNode,
+    clearAll,
+    setAllNodesStatus,
+  };
+}

--- a/frontend/app/components/pipeline-editor/hooks/usePipelineExecution.ts
+++ b/frontend/app/components/pipeline-editor/hooks/usePipelineExecution.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import type { DesignProposal } from "../utils/flowToDesign";
+
+interface PipelineStatus {
+  pipeline_id: string;
+  status: string;
+  design_name: string;
+  started_at: string;
+}
+
+export function usePipelineExecution(
+  updateNodeStatus: (nodeId: string, status: "running" | "completed" | "failed") => void,
+  setAllNodesStatus: (status: "idle" | "running" | "completed" | "failed") => void,
+  nodeNameToIdMap: () => Map<string, string>
+) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [currentAgent, setCurrentAgent] = useState<string | null>(null);
+  const wsListenerRef = useRef<((event: MessageEvent) => void) | null>(null);
+
+  const executeFromEditor = useCallback(
+    async (design: DesignProposal) => {
+      setIsRunning(true);
+      setAllNodesStatus("idle");
+
+      try {
+        const result = await apiFetch<PipelineStatus>(
+          "/api/v1/pipelines/execute-direct",
+          {
+            method: "POST",
+            body: JSON.stringify({ design }),
+          }
+        );
+
+        if (result.status === "completed") {
+          setAllNodesStatus("completed");
+        } else if (result.status === "failed") {
+          setAllNodesStatus("failed");
+        }
+
+        return result;
+      } catch (error) {
+        setAllNodesStatus("failed");
+        throw error;
+      } finally {
+        setIsRunning(false);
+        setCurrentAgent(null);
+      }
+    },
+    [setAllNodesStatus]
+  );
+
+  // TODO: Wire attachWsListener to shared WebSocket in Phase 8B
+  // for real-time node status updates during chat-initiated pipeline runs.
+  const attachWsListener = useCallback(
+    (ws: WebSocket) => {
+      // Remove previous listener if any
+      if (wsListenerRef.current) {
+        ws.removeEventListener("message", wsListenerRef.current);
+      }
+
+      const listener = (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(event.data);
+          const nameMap = nodeNameToIdMap();
+
+          if (data.type === "pipeline_started") {
+            setIsRunning(true);
+            setAllNodesStatus("idle");
+          }
+
+          if (data.type === "agent_completed") {
+            const agentName = data.agent_name as string;
+            setCurrentAgent(agentName);
+            const nodeId = nameMap.get(agentName);
+            if (nodeId) {
+              updateNodeStatus(nodeId, "completed");
+            }
+          }
+
+          if (data.type === "pipeline_result") {
+            setIsRunning(false);
+            setCurrentAgent(null);
+            setAllNodesStatus("completed");
+          }
+
+          if (data.type === "pipeline_failed") {
+            setIsRunning(false);
+            setCurrentAgent(null);
+          }
+        } catch {
+          // Ignore non-JSON messages
+        }
+      };
+
+      ws.addEventListener("message", listener);
+      wsListenerRef.current = listener;
+    },
+    [nodeNameToIdMap, setAllNodesStatus, updateNodeStatus]
+  );
+
+  return {
+    isRunning,
+    currentAgent,
+    executeFromEditor,
+    attachWsListener,
+  };
+}

--- a/frontend/app/components/pipeline-editor/hooks/useTemplates.ts
+++ b/frontend/app/components/pipeline-editor/hooks/useTemplates.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { apiFetch } from "@/lib/api";
+
+export interface TemplateListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TemplateDetail extends TemplateListItem {
+  graph_data: { nodes: unknown[]; edges: unknown[] };
+  design_data: Record<string, unknown>;
+}
+
+export function useTemplates() {
+  const [templates, setTemplates] = useState<TemplateListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchTemplates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await apiFetch<TemplateListItem[]>("/api/v1/templates");
+      setTemplates(data);
+    } catch (error) {
+      console.error("Failed to fetch templates:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadTemplate = useCallback(async (id: string): Promise<TemplateDetail | null> => {
+    try {
+      return await apiFetch<TemplateDetail>(`/api/v1/templates/${id}`);
+    } catch (error) {
+      console.error("Failed to load template:", error);
+      return null;
+    }
+  }, []);
+
+  const saveTemplate = useCallback(
+    async (data: {
+      name: string;
+      description: string;
+      graph_data: Record<string, unknown>;
+      design_data: Record<string, unknown>;
+    }) => {
+      try {
+        await apiFetch("/api/v1/templates", {
+          method: "POST",
+          body: JSON.stringify(data),
+        });
+        await fetchTemplates();
+      } catch (error) {
+        console.error("Failed to save template:", error);
+        throw error;
+      }
+    },
+    [fetchTemplates]
+  );
+
+  const deleteTemplate = useCallback(
+    async (id: string) => {
+      try {
+        await apiFetch(`/api/v1/templates/${id}`, { method: "DELETE" });
+        await fetchTemplates();
+      } catch (error) {
+        console.error("Failed to delete template:", error);
+        throw error;
+      }
+    },
+    [fetchTemplates]
+  );
+
+  return {
+    templates,
+    loading,
+    fetchTemplates,
+    loadTemplate,
+    saveTemplate,
+    deleteTemplate,
+  };
+}

--- a/frontend/app/components/pipeline-editor/nodes/AgentNode.tsx
+++ b/frontend/app/components/pipeline-editor/nodes/AgentNode.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "reactflow";
+import { getRoleConfig } from "../utils/nodeDefaults";
+
+export interface AgentNodeData {
+  name: string;
+  role: string;
+  llmModel: string;
+  description: string;
+  status: "idle" | "running" | "completed" | "failed";
+}
+
+function AgentNodeComponent({ data, selected }: NodeProps<AgentNodeData>) {
+  const config = getRoleConfig(data.role);
+  const statusStyles: Record<string, string> = {
+    idle: "border-gray-600",
+    running: "border-blue-500 agent-node-running",
+    completed: "border-green-500",
+    failed: "border-red-500",
+  };
+
+  return (
+    <div
+      className={`bg-gray-800 rounded-lg border-2 ${statusStyles[data.status] || statusStyles.idle} ${
+        selected ? "ring-2 ring-primary-500" : ""
+      } min-w-[180px] shadow-lg`}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-gray-400 !w-3 !h-3 !border-2 !border-gray-600"
+      />
+
+      {/* Header */}
+      <div
+        className="px-3 py-2 rounded-t-md text-white text-xs font-semibold flex items-center gap-1.5"
+        style={{ backgroundColor: config.color }}
+      >
+        <span>{config.icon}</span>
+        <span>{config.label}</span>
+      </div>
+
+      {/* Body */}
+      <div className="px-3 py-2">
+        <div className="text-gray-100 text-sm font-medium truncate">
+          {data.name}
+        </div>
+        <div className="text-gray-400 text-xs mt-1 truncate">
+          {data.llmModel}
+        </div>
+        {data.status === "running" && (
+          <div className="text-blue-400 text-xs mt-1 flex items-center gap-1">
+            <span className="inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
+            Running...
+          </div>
+        )}
+        {data.status === "completed" && (
+          <div className="text-green-400 text-xs mt-1">Completed</div>
+        )}
+        {data.status === "failed" && (
+          <div className="text-red-400 text-xs mt-1">Failed</div>
+        )}
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-gray-400 !w-3 !h-3 !border-2 !border-gray-600"
+      />
+    </div>
+  );
+}
+
+export default memo(AgentNodeComponent);

--- a/frontend/app/components/pipeline-editor/nodes/AgentNodeTypes.ts
+++ b/frontend/app/components/pipeline-editor/nodes/AgentNodeTypes.ts
@@ -1,0 +1,5 @@
+import AgentNode from "./AgentNode";
+
+export const nodeTypes = {
+  agentNode: AgentNode,
+};

--- a/frontend/app/components/pipeline-editor/panels/PropertyPanel.tsx
+++ b/frontend/app/components/pipeline-editor/panels/PropertyPanel.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { Node } from "reactflow";
+import type { AgentNodeData } from "../nodes/AgentNode";
+import { AVAILABLE_MODELS, AVAILABLE_ROLES, getRoleConfig } from "../utils/nodeDefaults";
+import { useState, useEffect } from "react";
+
+interface PropertyPanelProps {
+  node: Node<AgentNodeData> | null;
+  onUpdate: (nodeId: string, data: Partial<AgentNodeData>) => void;
+  onDelete: (nodeId: string) => void;
+  onClose: () => void;
+}
+
+export default function PropertyPanel({
+  node,
+  onUpdate,
+  onDelete,
+  onClose,
+}: PropertyPanelProps) {
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("");
+  const [llmModel, setLlmModel] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (node) {
+      setName(node.data.name);
+      setRole(node.data.role);
+      setLlmModel(node.data.llmModel);
+      setDescription(node.data.description);
+    }
+  }, [node]);
+
+  if (!node) return null;
+
+  const handleApply = () => {
+    onUpdate(node.id, { name, role, llmModel, description });
+  };
+
+  const config = getRoleConfig(role);
+
+  return (
+    <div className="absolute right-0 top-0 h-full w-72 bg-gray-900 border-l border-gray-700 shadow-xl z-20 flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-200">Node Properties</h3>
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-200 text-lg"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Form */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+        {/* Color indicator */}
+        <div
+          className="h-1 rounded"
+          style={{ backgroundColor: config.color }}
+        />
+
+        {/* Name */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full bg-gray-800 text-gray-100 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500"
+          />
+        </div>
+
+        {/* Role */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Role</label>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="w-full bg-gray-800 text-gray-100 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500"
+          >
+            {AVAILABLE_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {getRoleConfig(r).icon} {getRoleConfig(r).label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* LLM Model */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">LLM Model</label>
+          <select
+            value={llmModel}
+            onChange={(e) => setLlmModel(e.target.value)}
+            className="w-full bg-gray-800 text-gray-100 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500"
+          >
+            {AVAILABLE_MODELS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full bg-gray-800 text-gray-100 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500 resize-none"
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="px-4 py-3 border-t border-gray-700 flex gap-2">
+        <button
+          onClick={handleApply}
+          className="flex-1 bg-primary-600 hover:bg-primary-700 text-white text-sm py-1.5 rounded transition-colors"
+        >
+          Apply
+        </button>
+        <button
+          onClick={() => onDelete(node.id)}
+          className="px-3 bg-red-700 hover:bg-red-600 text-white text-sm py-1.5 rounded transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/pipeline-editor/panels/TemplateListPanel.tsx
+++ b/frontend/app/components/pipeline-editor/panels/TemplateListPanel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { TemplateListItem } from "../hooks/useTemplates";
+
+interface TemplateListPanelProps {
+  mode: "save" | "load";
+  templates: TemplateListItem[];
+  loading: boolean;
+  onClose: () => void;
+  onSave: (name: string, description: string) => void;
+  onLoad: (id: string) => void;
+  onDelete: (id: string) => void;
+  onRefresh: () => void;
+}
+
+export default function TemplateListPanel({
+  mode,
+  templates,
+  loading,
+  onClose,
+  onSave,
+  onLoad,
+  onDelete,
+  onRefresh,
+}: TemplateListPanelProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    onRefresh();
+  }, [onRefresh]);
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave(name.trim(), description.trim());
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-[480px] max-h-[70vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-100">
+            {mode === "save" ? "Save Template" : "Load Template"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-200 text-xl"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {mode === "save" && (
+            <div className="space-y-3 mb-4">
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">
+                  Template Name
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="My Pipeline Template"
+                  className="w-full bg-gray-800 text-gray-100 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">
+                  Description (optional)
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                  className="w-full bg-gray-800 text-gray-100 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary-500 resize-none"
+                />
+              </div>
+              <button
+                onClick={handleSave}
+                disabled={!name.trim()}
+                className="w-full bg-primary-600 hover:bg-primary-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white py-2 rounded text-sm transition-colors"
+              >
+                Save Template
+              </button>
+            </div>
+          )}
+
+          {/* Template list */}
+          <div>
+            {mode === "load" && (
+              <h3 className="text-sm text-gray-400 mb-2">Your Templates</h3>
+            )}
+            {mode === "save" && templates.length > 0 && (
+              <h3 className="text-sm text-gray-400 mb-2 pt-2 border-t border-gray-700">
+                Existing Templates
+              </h3>
+            )}
+
+            {loading ? (
+              <div className="text-center text-gray-500 py-6 text-sm">
+                Loading...
+              </div>
+            ) : templates.length === 0 ? (
+              <div className="text-center text-gray-500 py-6 text-sm">
+                No templates saved yet
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {templates.map((t) => (
+                  <div
+                    key={t.id}
+                    className="bg-gray-800 rounded px-3 py-2.5 flex items-center justify-between"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-gray-100 font-medium truncate">
+                        {t.name}
+                      </div>
+                      {t.description && (
+                        <div className="text-xs text-gray-400 truncate">
+                          {t.description}
+                        </div>
+                      )}
+                      <div className="text-xs text-gray-500 mt-0.5">
+                        {new Date(t.updated_at).toLocaleDateString()}
+                      </div>
+                    </div>
+                    <div className="flex gap-1.5 ml-2">
+                      {mode === "load" && (
+                        <button
+                          onClick={() => {
+                            onLoad(t.id);
+                            onClose();
+                          }}
+                          className="px-2.5 py-1 bg-primary-600 hover:bg-primary-700 text-white text-xs rounded transition-colors"
+                        >
+                          Load
+                        </button>
+                      )}
+                      <button
+                        onClick={() => {
+                          if (window.confirm("Delete this template?")) {
+                            onDelete(t.id);
+                          }
+                        }}
+                        className="px-2.5 py-1 bg-gray-700 hover:bg-red-700 text-gray-300 hover:text-white text-xs rounded transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/pipeline-editor/panels/Toolbar.tsx
+++ b/frontend/app/components/pipeline-editor/panels/Toolbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { AVAILABLE_ROLES, getRoleConfig } from "../utils/nodeDefaults";
+
+interface ToolbarProps {
+  onAddNode: (role: string) => void;
+  onRun: () => void;
+  onSave: () => void;
+  onLoad: () => void;
+  onClear: () => void;
+  isRunning: boolean;
+  nodeCount: number;
+}
+
+export default function Toolbar({
+  onAddNode,
+  onRun,
+  onSave,
+  onLoad,
+  onClear,
+  isRunning,
+  nodeCount,
+}: ToolbarProps) {
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-gray-900 border-b border-gray-700">
+      {/* Add Node dropdown */}
+      <div className="relative">
+        <button
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+        >
+          + Add Node
+        </button>
+        {showDropdown && (
+          <div className="absolute top-full left-0 mt-1 bg-gray-800 border border-gray-600 rounded shadow-lg z-50 min-w-[180px]">
+            {AVAILABLE_ROLES.map((role) => {
+              const config = getRoleConfig(role);
+              return (
+                <button
+                  key={role}
+                  onClick={() => {
+                    onAddNode(role);
+                    setShowDropdown(false);
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                >
+                  <span>{config.icon}</span>
+                  <span>{config.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="w-px h-6 bg-gray-700" />
+
+      {/* Run */}
+      <button
+        onClick={onRun}
+        disabled={isRunning || nodeCount === 0}
+        className="px-3 py-1.5 bg-green-700 hover:bg-green-600 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm rounded transition-colors"
+      >
+        {isRunning ? "Running..." : "Run"}
+      </button>
+
+      {/* Save / Load */}
+      <button
+        onClick={onSave}
+        disabled={nodeCount === 0}
+        className="px-3 py-1.5 bg-blue-700 hover:bg-blue-600 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm rounded transition-colors"
+      >
+        Save
+      </button>
+      <button
+        onClick={onLoad}
+        className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+      >
+        Load
+      </button>
+
+      {/* Divider */}
+      <div className="w-px h-6 bg-gray-700" />
+
+      {/* Clear */}
+      <button
+        onClick={onClear}
+        disabled={nodeCount === 0}
+        className="px-3 py-1.5 bg-gray-700 hover:bg-red-700 disabled:cursor-not-allowed text-gray-300 hover:text-white text-sm rounded transition-colors"
+      >
+        Clear
+      </button>
+
+      {/* Node count */}
+      <span className="text-xs text-gray-500 ml-auto">
+        {nodeCount} node{nodeCount !== 1 ? "s" : ""}
+      </span>
+    </div>
+  );
+}

--- a/frontend/app/components/pipeline-editor/utils/designToFlow.ts
+++ b/frontend/app/components/pipeline-editor/utils/designToFlow.ts
@@ -1,0 +1,57 @@
+// Convert DesignProposal to React Flow nodes + edges for visualization
+
+import type { Edge, Node } from "reactflow";
+import type { AgentNodeData } from "../nodes/AgentNode";
+
+interface AgentSpec {
+  name: string;
+  role: string;
+  llm_model: string;
+  description: string;
+}
+
+interface DesignProposal {
+  name: string;
+  description: string;
+  agents: AgentSpec[];
+}
+
+const VERTICAL_SPACING = 150;
+const X_CENTER = 300;
+
+/**
+ * Convert a DesignProposal into React Flow nodes and edges.
+ * Lays out nodes vertically in sequential order.
+ */
+export function designToFlow(design: DesignProposal): {
+  nodes: Node<AgentNodeData>[];
+  edges: Edge[];
+} {
+  const nodes: Node<AgentNodeData>[] = design.agents.map((agent, index) => ({
+    id: `agent-${index + 1}`,
+    type: "agentNode",
+    position: {
+      x: X_CENTER,
+      y: index * VERTICAL_SPACING + 50,
+    },
+    data: {
+      name: agent.name,
+      role: agent.role,
+      llmModel: agent.llm_model,
+      description: agent.description,
+      status: "idle" as const,
+    },
+  }));
+
+  const edges: Edge[] = [];
+  for (let i = 0; i < nodes.length - 1; i++) {
+    edges.push({
+      id: `edge-${nodes[i].id}-${nodes[i + 1].id}`,
+      source: nodes[i].id,
+      target: nodes[i + 1].id,
+      animated: false,
+    });
+  }
+
+  return { nodes, edges };
+}

--- a/frontend/app/components/pipeline-editor/utils/flowToDesign.ts
+++ b/frontend/app/components/pipeline-editor/utils/flowToDesign.ts
@@ -1,0 +1,99 @@
+// Convert React Flow graph (nodes + edges) to DesignProposal for backend execution
+
+import type { Edge, Node } from "reactflow";
+import type { AgentNodeData } from "../nodes/AgentNode";
+
+export interface AgentSpec {
+  name: string;
+  role: string;
+  llm_model: string;
+  description: string;
+}
+
+export interface DesignProposal {
+  name: string;
+  description: string;
+  agents: AgentSpec[];
+  pros: string[];
+  cons: string[];
+  estimated_cost: string;
+  complexity: string;
+  recommended: boolean;
+}
+
+/**
+ * Topological sort of nodes based on edges.
+ * Throws if a cycle is detected or nodes are disconnected.
+ */
+function topologicalSort(
+  nodes: Node<AgentNodeData>[],
+  edges: Edge[]
+): Node<AgentNodeData>[] {
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+
+  for (const node of nodes) {
+    inDegree.set(node.id, 0);
+    adjacency.set(node.id, []);
+  }
+
+  for (const edge of edges) {
+    adjacency.get(edge.source)?.push(edge.target);
+    inDegree.set(edge.target, (inDegree.get(edge.target) || 0) + 1);
+  }
+
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree.entries()) {
+    if (deg === 0) queue.push(id);
+  }
+
+  const sorted: string[] = [];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    sorted.push(current);
+    for (const neighbor of adjacency.get(current) || []) {
+      const newDeg = (inDegree.get(neighbor) || 1) - 1;
+      inDegree.set(neighbor, newDeg);
+      if (newDeg === 0) queue.push(neighbor);
+    }
+  }
+
+  if (sorted.length !== nodes.length) {
+    throw new Error("Cycle detected in pipeline graph");
+  }
+
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+  return sorted.map((id) => nodeMap.get(id)!);
+}
+
+/**
+ * Convert React Flow nodes + edges into a DesignProposal.
+ */
+export function flowToDesign(
+  nodes: Node<AgentNodeData>[],
+  edges: Edge[]
+): DesignProposal {
+  if (nodes.length === 0) {
+    throw new Error("Pipeline must have at least one agent");
+  }
+
+  const sortedNodes = topologicalSort(nodes, edges);
+
+  const agents: AgentSpec[] = sortedNodes.map((node) => ({
+    name: node.data.name,
+    role: node.data.role,
+    llm_model: node.data.llmModel,
+    description: node.data.description || `${node.data.role} agent`,
+  }));
+
+  return {
+    name: "Custom Pipeline",
+    description: "Pipeline created from visual editor",
+    agents,
+    pros: [],
+    cons: [],
+    estimated_cost: "varies",
+    complexity: agents.length <= 2 ? "low" : agents.length <= 4 ? "medium" : "high",
+    recommended: false,
+  };
+}

--- a/frontend/app/components/pipeline-editor/utils/nodeDefaults.ts
+++ b/frontend/app/components/pipeline-editor/utils/nodeDefaults.ts
@@ -1,0 +1,73 @@
+// Default settings for each agent role
+
+export interface RoleConfig {
+  label: string;
+  color: string;
+  defaultModel: string;
+  icon: string;
+}
+
+export const ROLE_CONFIGS: Record<string, RoleConfig> = {
+  collector: {
+    label: "Collector",
+    color: "#3b82f6", // blue
+    defaultModel: "gpt-4o-mini",
+    icon: "📥",
+  },
+  analyzer: {
+    label: "Analyzer",
+    color: "#8b5cf6", // violet
+    defaultModel: "gpt-4o",
+    icon: "🔍",
+  },
+  validator: {
+    label: "Validator",
+    color: "#f59e0b", // amber
+    defaultModel: "gpt-4o-mini",
+    icon: "✅",
+  },
+  reporter: {
+    label: "Reporter",
+    color: "#10b981", // emerald
+    defaultModel: "gpt-4o-mini",
+    icon: "📊",
+  },
+  synthesizer: {
+    label: "Synthesizer",
+    color: "#ec4899", // pink
+    defaultModel: "gpt-4o",
+    icon: "🧬",
+  },
+  critic: {
+    label: "Critic",
+    color: "#ef4444", // red
+    defaultModel: "gpt-4o",
+    icon: "🎯",
+  },
+  cross_checker: {
+    label: "Cross Checker",
+    color: "#f97316", // orange
+    defaultModel: "gpt-4o",
+    icon: "🔄",
+  },
+};
+
+export const AVAILABLE_ROLES = Object.keys(ROLE_CONFIGS);
+
+export const AVAILABLE_MODELS = [
+  "gpt-4o",
+  "gpt-4o-mini",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+];
+
+export function getRoleConfig(role: string): RoleConfig {
+  return (
+    ROLE_CONFIGS[role] || {
+      label: role,
+      color: "#6b7280",
+      defaultModel: "gpt-4o-mini",
+      icon: "⚙️",
+    }
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -74,3 +74,37 @@ body {
 .typing-dot:nth-child(3) {
   animation-delay: 0.4s;
 }
+
+/* React Flow overrides */
+.react-flow__node {
+  cursor: pointer;
+}
+
+.react-flow__edge-path {
+  stroke: #6b7280;
+  stroke-width: 2;
+}
+
+.react-flow__edge.animated .react-flow__edge-path {
+  stroke: #3b82f6;
+}
+
+.react-flow__connection-line {
+  stroke: #6b7280;
+  stroke-width: 2;
+  stroke-dasharray: 5;
+}
+
+/* Agent node running animation */
+@keyframes nodePulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(59, 130, 246, 0);
+  }
+}
+
+.agent-node-running {
+  animation: nodePulse 2s ease-in-out infinite;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,49 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import ChatWindow from "./components/ChatWindow";
+import SplitView from "./components/SplitView";
+
+const PipelineEditor = dynamic(
+  () => import("./components/pipeline-editor/PipelineEditor"),
+  { ssr: false }
+);
+
+const EDITOR_OPEN_KEY = "agentforge-editor-open";
 
 export default function Home() {
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const loadDesignRef = useRef<((design: Record<string, unknown>) => void) | null>(null);
+
+  // Restore editor open state from localStorage
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(EDITOR_OPEN_KEY);
+      if (saved === "true") setIsEditorOpen(true);
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  // Persist editor open state
+  useEffect(() => {
+    try {
+      localStorage.setItem(EDITOR_OPEN_KEY, String(isEditorOpen));
+    } catch {
+      // Ignore
+    }
+  }, [isEditorOpen]);
+
+  const handleEditorReady = useCallback((loadDesign: (design: Record<string, unknown>) => void) => {
+    loadDesignRef.current = loadDesign;
+  }, []);
+
+  const handleOpenDesign = useCallback((design: Record<string, unknown>) => {
+    setIsEditorOpen(true);
+    loadDesignRef.current?.(design);
+  }, []);
+
   return (
     <main className="min-h-screen bg-gray-950 flex flex-col">
       <header className="bg-gray-900 border-b border-gray-800 px-6 py-4">
@@ -8,7 +51,12 @@ export default function Home() {
         <p className="text-sm text-gray-400 mt-1">User-prompt driven multi-agent platform</p>
       </header>
       <div className="flex-1 overflow-hidden">
-        <ChatWindow />
+        <SplitView
+          left={<ChatWindow onOpenDesign={handleOpenDesign} />}
+          right={<PipelineEditor onEditorReady={handleEditorReady} />}
+          isEditorOpen={isEditorOpen}
+          onEditorToggle={setIsEditorOpen}
+        />
       </div>
     </main>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,42 @@
+// REST API fetch wrapper with JWT authentication
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+function getAuthHeaders(): Record<string, string> {
+  const token =
+    typeof window !== "undefined"
+      ? localStorage.getItem("access_token")
+      : null;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const url = `${API_URL}${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      ...getAuthHeaders(),
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(error.detail || `API error: ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.2.15",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "reactflow": "^11.11.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -490,6 +491,108 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -531,6 +634,265 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -552,14 +914,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1733,6 +2095,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1808,8 +2176,114 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2373,6 +2847,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4756,6 +5231,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5909,6 +6402,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6150,6 +6652,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,17 +11,18 @@
   "dependencies": {
     "next": "14.2.15",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.15",
-    "typescript": "^5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "autoprefixer": "^10.0.1"
+    "typescript": "^5"
   }
 }

--- a/tests/unit/test_direct_execute.py
+++ b/tests/unit/test_direct_execute.py
@@ -1,0 +1,135 @@
+"""Tests for pipeline execute-direct API endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.gateway.auth import get_current_user
+from backend.gateway.main import app
+from backend.pipeline.result import PipelineResult
+from backend.shared.models import User, UserRole
+
+
+def _mock_current_user() -> User:
+    """Create a mock authenticated user."""
+    user = User(
+        id=uuid.uuid4(),
+        email="test@example.com",
+        hashed_password="hashed",
+        display_name="Test User",
+        role=UserRole.FREE,
+    )
+    return user
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_user] = _mock_current_user
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _make_design_dict() -> dict:
+    """Create a test design dict for API requests."""
+    return {
+        "name": "Test Pipeline",
+        "description": "A test pipeline",
+        "agents": [
+            {
+                "name": "analyzer",
+                "role": "analyzer",
+                "llm_model": "gpt-4o-mini",
+                "description": "Analyzes",
+            },
+        ],
+        "pros": ["fast"],
+        "cons": ["simple"],
+        "estimated_cost": "~$0.01",
+        "complexity": "low",
+        "recommended": False,
+    }
+
+
+class TestExecuteDirect:
+    """Tests for POST /api/v1/pipelines/execute-direct."""
+
+    @patch("backend.gateway.routes.pipeline.PipelineOrchestrator")
+    def test_execute_direct_success(self, mock_orch_class, client):
+        mock_result = PipelineResult(
+            design_name="Test Pipeline",
+            status="completed",
+            agent_results=[],
+            total_cost=0.01,
+            total_duration=5.0,
+            total_tokens=500,
+            output="Final output from direct execution",
+        )
+        mock_orch = AsyncMock()
+        mock_orch.execute = AsyncMock(return_value=mock_result)
+        mock_orch_class.return_value = mock_orch
+
+        response = client.post(
+            "/api/v1/pipelines/execute-direct",
+            json={"design": _make_design_dict()},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "completed"
+        assert data["design_name"] == "Test Pipeline"
+        assert data["result"]["output"] == "Final output from direct execution"
+
+    def test_execute_direct_invalid_design(self, client):
+        response = client.post(
+            "/api/v1/pipelines/execute-direct",
+            json={"design": {"invalid": "data"}},
+        )
+        assert response.status_code == 422
+
+    def test_execute_direct_no_design(self, client):
+        response = client.post(
+            "/api/v1/pipelines/execute-direct",
+            json={},
+        )
+        assert response.status_code == 422
+
+    @patch("backend.gateway.routes.pipeline.PipelineOrchestrator")
+    def test_execute_direct_shares_logic_with_execute(self, mock_orch_class, client):
+        """Both endpoints should produce similar responses for the same input."""
+        mock_result = PipelineResult(
+            design_name="Test Pipeline",
+            status="completed",
+            agent_results=[],
+            total_cost=0.02,
+            total_duration=3.0,
+            total_tokens=300,
+            output="Shared logic output",
+        )
+        mock_orch = AsyncMock()
+        mock_orch.execute = AsyncMock(return_value=mock_result)
+        mock_orch_class.return_value = mock_orch
+
+        design = _make_design_dict()
+
+        resp1 = client.post("/api/v1/pipelines/execute", json={"design": design})
+        resp2 = client.post("/api/v1/pipelines/execute-direct", json={"design": design})
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        # Both should return the same structure
+        assert resp1.json()["status"] == resp2.json()["status"]
+        assert resp1.json()["design_name"] == resp2.json()["design_name"]
+
+    @patch("backend.gateway.routes.pipeline.check_budget")
+    def test_execute_direct_budget_exceeded(self, mock_budget, client):
+        mock_budget.return_value = (False, 10.0, 5.0)
+
+        response = client.post(
+            "/api/v1/pipelines/execute-direct",
+            json={"design": _make_design_dict()},
+        )
+        assert response.status_code == 402
+        assert "cost limit" in response.json()["detail"].lower()

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -1,0 +1,231 @@
+"""Tests for pipeline template CRUD API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.gateway.auth import get_current_user
+from backend.gateway.main import app
+from backend.shared.models import User, UserRole
+
+
+def _mock_current_user() -> User:
+    """Create a mock authenticated user."""
+    user = User(
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        email="test@example.com",
+        hashed_password="hashed",
+        display_name="Test User",
+        role=UserRole.FREE,
+    )
+    return user
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_user] = _mock_current_user
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _make_template_data() -> dict:
+    """Create valid template request data."""
+    return {
+        "name": "Test Pipeline Template",
+        "description": "A test template",
+        "graph_data": {
+            "nodes": [
+                {
+                    "id": "agent-1",
+                    "type": "agentNode",
+                    "position": {"x": 300, "y": 50},
+                    "data": {
+                        "name": "analyzer",
+                        "role": "analyzer",
+                        "llmModel": "gpt-4o-mini",
+                        "description": "Analyzes data",
+                        "status": "idle",
+                    },
+                }
+            ],
+            "edges": [],
+        },
+        "design_data": {
+            "name": "Test Pipeline",
+            "description": "A test pipeline",
+            "agents": [
+                {
+                    "name": "analyzer",
+                    "role": "analyzer",
+                    "llm_model": "gpt-4o-mini",
+                    "description": "Analyzes data",
+                }
+            ],
+            "pros": [],
+            "cons": [],
+            "estimated_cost": "~$0.01",
+            "complexity": "low",
+            "recommended": False,
+        },
+    }
+
+
+class TestTemplateSchemaValidation:
+    """Tests for template schema validation (no DB needed)."""
+
+    def test_create_template_invalid_name_empty(self, client):
+        data = _make_template_data()
+        data["name"] = ""
+        response = client.post("/api/v1/templates", json=data)
+        assert response.status_code == 422
+
+    def test_create_template_name_too_long(self, client):
+        data = _make_template_data()
+        data["name"] = "x" * 256
+        response = client.post("/api/v1/templates", json=data)
+        assert response.status_code == 422
+
+    def test_create_template_missing_graph_data(self, client):
+        data = _make_template_data()
+        del data["graph_data"]
+        response = client.post("/api/v1/templates", json=data)
+        assert response.status_code == 422
+
+    def test_create_template_missing_design_data(self, client):
+        data = _make_template_data()
+        del data["design_data"]
+        response = client.post("/api/v1/templates", json=data)
+        assert response.status_code == 422
+
+    def test_get_template_invalid_uuid(self, client):
+        response = client.get("/api/v1/templates/not-a-uuid")
+        assert response.status_code == 422
+
+    def test_update_template_invalid_uuid(self, client):
+        response = client.put(
+            "/api/v1/templates/not-a-uuid",
+            json={"name": "Updated"},
+        )
+        assert response.status_code == 422
+
+    def test_delete_template_invalid_uuid(self, client):
+        response = client.delete("/api/v1/templates/not-a-uuid")
+        assert response.status_code == 422
+
+
+class TestTemplateRouteExists:
+    """Tests that template routes are registered and require auth."""
+
+    def test_list_templates_requires_auth(self):
+        """Templates endpoint exists and requires authentication."""
+        # No dependency overrides — should fail auth
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/api/v1/templates")
+        # 401 (no token) or 500 (DB not available) — either means route exists
+        assert response.status_code in (401, 403, 500)
+
+    def test_create_template_route_exists(self, client):
+        """POST /templates route exists and validates input."""
+        response = client.post("/api/v1/templates", json={})
+        assert response.status_code == 422
+
+    def test_execute_direct_route_exists(self, client):
+        """POST /pipelines/execute-direct route exists."""
+        response = client.post("/api/v1/pipelines/execute-direct", json={})
+        assert response.status_code == 422
+
+
+class TestTemplateResponseSchema:
+    """Tests for template response schema models."""
+
+    def test_template_create_schema(self):
+        from backend.shared.schemas import TemplateCreate
+
+        data = _make_template_data()
+        schema = TemplateCreate(**data)
+        assert schema.name == "Test Pipeline Template"
+        assert schema.description == "A test template"
+        assert "nodes" in schema.graph_data
+        assert "agents" in schema.design_data
+
+    def test_template_update_schema_partial(self):
+        from backend.shared.schemas import TemplateUpdate
+
+        schema = TemplateUpdate(name="New Name")
+        dumped = schema.model_dump(exclude_unset=True)
+        assert dumped == {"name": "New Name"}
+
+    def test_template_update_schema_empty(self):
+        from backend.shared.schemas import TemplateUpdate
+
+        schema = TemplateUpdate()
+        dumped = schema.model_dump(exclude_unset=True)
+        assert dumped == {}
+
+    def test_template_response_schema(self):
+        from backend.shared.schemas import TemplateResponse
+
+        data = {
+            "id": uuid.uuid4(),
+            "name": "Test",
+            "description": None,
+            "graph_data": {},
+            "design_data": {},
+            "is_public": False,
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        }
+        schema = TemplateResponse(**data)
+        assert schema.name == "Test"
+        assert schema.is_public is False
+
+    def test_template_list_response_schema(self):
+        from backend.shared.schemas import TemplateListResponse
+
+        data = {
+            "id": uuid.uuid4(),
+            "name": "Test",
+            "description": "desc",
+            "is_public": True,
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        }
+        schema = TemplateListResponse(**data)
+        assert schema.name == "Test"
+        assert schema.is_public is True
+
+
+class TestPipelineTemplateModel:
+    """Tests for the PipelineTemplate SQLAlchemy model."""
+
+    def test_model_exists(self):
+        from backend.shared.models import PipelineTemplate
+
+        assert PipelineTemplate.__tablename__ == "pipeline_templates"
+
+    def test_model_fields(self):
+        from backend.shared.models import PipelineTemplate
+
+        columns = {c.name for c in PipelineTemplate.__table__.columns}
+        expected = {
+            "id",
+            "user_id",
+            "name",
+            "description",
+            "graph_data",
+            "design_data",
+            "is_public",
+            "created_at",
+            "updated_at",
+        }
+        assert expected.issubset(columns)
+
+    def test_user_relationship(self):
+        from backend.shared.models import User
+
+        # Verify templates relationship exists on User
+        mapper = User.__mapper__
+        assert "templates" in mapper.relationships


### PR DESCRIPTION
## Summary
- **Phase 2C**: API Key 관리 + 비용 회로 차단기 (PR #19, Issue #18)
- **Phase 8A**: React Flow 파이프라인 에디터 + Split View (PR #22, Issue #21)

## Changes

### Phase 2C: API Key + Cost Circuit Breaker
- API Key CRUD (생성/목록/삭제/토글)
- X-API-Key 헤더 인증 (JWT 대안)
- Redis 기반 일일 비용 추적 + 회로 차단기
- 파이프라인 락 (TOCTOU 방지)
- IDOR 방지 (404 통일 응답)

### Phase 8A: React Flow Pipeline Editor
- PipelineTemplate DB 모델 + Alembic 마이그레이션
- Template CRUD API (5개 엔드포인트, 사용자당 50개 제한)
- execute-direct 엔드포인트 (토론 엔진 우회)
- React Flow v11 시각적 파이프라인 에디터
  - 커스텀 AgentNode (역할별 색상/아이콘, 실행 상태 표시)
  - Toolbar (노드 추가, 실행, 저장/불러오기, 초기화)
  - PropertyPanel (노드 속성 편집)
  - TemplateListPanel (템플릿 저장/불러오기 모달)
- SplitView (리사이즈 가능한 분할 패널: 채팅 + 에디터)
- flowToDesign/designToFlow 변환 유틸리티 (위상 정렬 DAG 검증)
- 채팅 → 에디터 연동 ("에디터에서 열기" 버튼, React callback props)

### 새로 추가된 파일 (주요)
- `backend/gateway/cost_tracker.py` — Redis 비용 추적
- `backend/gateway/routes/api_keys.py` — API Key CRUD
- `backend/gateway/routes/templates.py` — Template CRUD
- `backend/alembic/versions/..._0002_api_keys_and_costs.py` — API Key 마이그레이션
- `backend/alembic/versions/..._0003_pipeline_templates.py` — Template 마이그레이션
- `frontend/app/components/pipeline-editor/**` — React Flow 에디터 (18개 파일)
- `frontend/app/components/SplitView.tsx` — 분할 패널
- `frontend/lib/api.ts` — REST API fetch 래퍼

## Verification
- [x] 506 전체 테스트 통과
- [x] ruff format/check 통과
- [x] TypeScript 컴파일 통과 (tsc --noEmit)
- [x] ESLint 통과
- [x] frontend build 통과

## Review Points
- Phase 2C: 4회 리뷰 사이클 완료 (TOCTOU, IDOR, 로그 인젝션, Redis 원자성)
- Phase 8A: 3회 리뷰 사이클 완료 (DOM→callback, JSON 크기 제한, user_id 인덱스)

Closes #18, Closes #21