### PR TITLE
test: 실제 LLM 연동 테스트 추가 (#30)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
       - run: pip install -r backend/requirements.txt && pip install pytest pytest-asyncio httpx aiosqlite
-      - run: cd backend && python -m pytest ../tests/ -v --tb=short
+      - run: cd backend && python -m pytest ../tests/ -v --tb=short -m "not llm_integration"
         env:
           DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/agentforge_test
           REDIS_URL: redis://localhost:6379

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "llm_integration: tests that require real LLM API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY)",
+]

--- a/tests/integration/test_llm_real.py
+++ b/tests/integration/test_llm_real.py
@@ -1,0 +1,180 @@
+"""Real LLM integration tests — requires actual API keys.
+
+Run with: OPENAI_API_KEY=sk-xxx pytest tests/integration/test_llm_real.py -v -m llm_integration
+Cost: ~$0.001 per full run (gpt-4o-mini)
+"""
+
+import os
+
+import pytest
+
+from backend.pipeline.llm_router import (
+    AnthropicClient,
+    LLMRouter,
+    OpenAIClient,
+    TaskComplexity,
+)
+
+pytestmark = [
+    pytest.mark.llm_integration,
+    pytest.mark.skipif(
+        not os.getenv("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not set",
+    ),
+]
+
+
+@pytest.fixture
+def openai_client():
+    return OpenAIClient()
+
+
+@pytest.fixture
+def router():
+    return LLMRouter()
+
+
+class TestOpenAIClientReal:
+    """Tests using real OpenAI API calls."""
+
+    async def test_openai_client_real_call(self, openai_client):
+        """OpenAIClient.generate() returns valid LLMResponse structure."""
+        messages = [{"role": "user", "content": "Say 'hello' in one word."}]
+        response = await openai_client.generate(
+            messages=messages,
+            model="gpt-4o-mini",
+            max_tokens=10,
+            temperature=0.0,
+        )
+
+        assert response.content, "Response content should not be empty"
+        assert response.model == "gpt-4o-mini"
+        assert response.provider == "openai"
+        assert isinstance(response.usage, dict)
+        assert response.usage["prompt_tokens"] > 0
+        assert response.usage["completion_tokens"] > 0
+        assert response.usage["total_tokens"] > 0
+
+    async def test_cost_calculation_real(self, router):
+        """LLMRouter.generate() calculates cost_estimate > 0."""
+        messages = [{"role": "user", "content": "Say 'yes'."}]
+        response = await router.generate(
+            messages=messages,
+            complexity=TaskComplexity.SIMPLE,
+            max_tokens=5,
+            temperature=0.0,
+        )
+
+        assert response.cost_estimate > 0, "Cost estimate should be positive"
+
+    async def test_token_usage_tracking(self, router):
+        """Usage dict contains prompt_tokens and completion_tokens."""
+        messages = [{"role": "user", "content": "Reply with the number 42."}]
+        response = await router.generate(
+            messages=messages,
+            complexity=TaskComplexity.SIMPLE,
+            max_tokens=10,
+            temperature=0.0,
+        )
+
+        assert "prompt_tokens" in response.usage
+        assert "completion_tokens" in response.usage
+        assert "total_tokens" in response.usage
+        assert response.usage["prompt_tokens"] > 0
+        assert response.usage["completion_tokens"] > 0
+
+    async def test_error_handling_invalid_key(self):
+        """Invalid API key raises an error gracefully."""
+        client = OpenAIClient()
+        # Temporarily override the client with invalid key
+        from openai import AsyncOpenAI
+
+        client._client = AsyncOpenAI(api_key="sk-invalid-key-for-testing")
+
+        messages = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(Exception):
+            await client.generate(
+                messages=messages,
+                model="gpt-4o-mini",
+                max_tokens=5,
+            )
+
+
+class TestRouterReal:
+    """Tests for LLMRouter with real API."""
+
+    async def test_router_auto_routing(self, router):
+        """LLMRouter routes based on complexity classification."""
+        # Simple prompt should use gpt-4o-mini
+        simple_messages = [{"role": "user", "content": "Hi"}]
+        response = await router.generate(
+            messages=simple_messages,
+            max_tokens=5,
+            temperature=0.0,
+        )
+        assert response.model == "gpt-4o-mini"
+        assert response.provider == "openai"
+
+
+class TestIntentAnalyzerReal:
+    """Tests for IntentAnalyzer with real LLM."""
+
+    async def test_intent_analyzer_real(self):
+        """IntentAnalyzer returns valid IntentResult from real LLM."""
+        from backend.discussion.intent_analyzer import IntentAnalyzer
+
+        analyzer = IntentAnalyzer()
+        result = await analyzer.analyze("AI 뉴스를 분석해줘")
+
+        assert result.task, "Task should not be empty"
+        assert result.confidence > 0, "Confidence should be positive"
+        assert result.summary, "Summary should not be empty"
+        assert result.estimated_complexity in ("simple", "standard", "complex")
+
+
+class TestDesignGeneratorReal:
+    """Tests for DesignGenerator with real LLM."""
+
+    async def test_design_generator_real(self):
+        """DesignGenerator returns list of DesignProposal from real LLM."""
+        from backend.discussion.design_generator import DesignGenerator
+
+        generator = DesignGenerator()
+        requirements = {
+            "task": "sentiment_analysis",
+            "source_type": "web_reviews",
+            "output_format": "report",
+            "estimated_complexity": "standard",
+        }
+        designs = await generator.generate_designs(requirements)
+
+        assert len(designs) >= 1, "Should return at least 1 design"
+        for design in designs:
+            assert design.name, "Design name should not be empty"
+            assert design.description, "Design description should not be empty"
+            assert len(design.agents) >= 1, "Design should have at least 1 agent"
+
+
+class TestAnthropicClientReal:
+    """Tests for AnthropicClient — only runs if ANTHROPIC_API_KEY is set."""
+
+    @pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY not set",
+    )
+    async def test_anthropic_client_real_call(self):
+        """AnthropicClient.generate() returns valid LLMResponse."""
+        client = AnthropicClient()
+        messages = [{"role": "user", "content": "Say 'hello' in one word."}]
+        response = await client.generate(
+            messages=messages,
+            model="claude-haiku-4-5-20251001",
+            max_tokens=10,
+            temperature=0.0,
+        )
+
+        assert response.content, "Response content should not be empty"
+        assert response.provider == "anthropic"
+        assert isinstance(response.usage, dict)
+        assert response.usage["prompt_tokens"] > 0
+        assert response.usage["completion_tokens"] > 0

--- a/tests/integration/test_pipeline_real.py
+++ b/tests/integration/test_pipeline_real.py
@@ -1,0 +1,63 @@
+"""Real pipeline execution tests — requires actual API keys.
+
+Run with: OPENAI_API_KEY=sk-xxx pytest tests/integration/test_pipeline_real.py -v -m llm_integration
+"""
+
+import os
+
+import pytest
+
+from backend.discussion.design_generator import AgentSpec, DesignProposal
+from backend.pipeline.orchestrator import PipelineOrchestrator
+
+pytestmark = [
+    pytest.mark.llm_integration,
+    pytest.mark.skipif(
+        not os.getenv("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not set",
+    ),
+]
+
+
+class TestPipelineReal:
+    """Tests for PipelineOrchestrator with real LLM."""
+
+    async def test_single_agent_pipeline_real(self):
+        """Single-agent pipeline executes and returns valid PipelineResult."""
+        design = DesignProposal(
+            name="Single Agent Test",
+            description="A simple test pipeline with one agent",
+            agents=[
+                AgentSpec(
+                    name="analyzer",
+                    role="analyzer",
+                    llm_model="gpt-4o-mini",
+                    description="Analyzes the given topic briefly",
+                ),
+            ],
+            pros=["Simple"],
+            cons=["Limited"],
+            estimated_cost="~$0.001",
+            complexity="low",
+            recommended=True,
+        )
+
+        orchestrator = PipelineOrchestrator()
+        status_updates = []
+
+        async def on_status(data):
+            status_updates.append(data)
+
+        result = await orchestrator.execute(
+            design=design,
+            on_status=on_status,
+            timeout=60,
+        )
+
+        assert result.design_name == "Single Agent Test"
+        assert result.status in ("completed", "partial", "failed")
+        assert result.total_duration > 0
+
+        # Should have received status updates
+        assert len(status_updates) >= 1
+        assert status_updates[0]["type"] == "pipeline_started"


### PR DESCRIPTION
## Summary
- 실제 OpenAI/Anthropic API를 사용하는 통합 테스트 9개 추가
- `@pytest.mark.llm_integration` 마커로 분리, API 키 없으면 자동 스킵
- CI 워크플로우에 `-m "not llm_integration"` 추가하여 일반 테스트에 영향 없음

## 변경 사항
| 파일 | 변경 |
|------|------|
| `tests/integration/test_llm_real.py` | 실제 API 호출 테스트 8개 (신규) |
| `tests/integration/test_pipeline_real.py` | 파이프라인 실행 테스트 1개 (신규) |
| `pyproject.toml` | `llm_integration` 마커 등록 |
| `.github/workflows/test.yml` | LLM 테스트 CI 제외 |

## 테스트 목록
1. `test_openai_client_real_call` — OpenAIClient.generate() 직접 호출
2. `test_router_auto_routing` — 복잡도별 모델 선택
3. `test_intent_analyzer_real` — IntentResult JSON 파싱
4. `test_design_generator_real` — DesignProposal 반환
5. `test_cost_calculation_real` — cost_estimate > 0
6. `test_token_usage_tracking` — usage dict 검증
7. `test_error_handling_invalid_key` — 잘못된 API 키 처리
8. `test_anthropic_client_real_call` — Anthropic 클라이언트
9. `test_single_agent_pipeline_real` — 1-agent 파이프라인

## Test plan
- [x] 기존 597개 테스트 통과 (9개 LLM 테스트 deselected)
- [ ] `OPENAI_API_KEY` 설정 후 수동 실행 검증

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)