### PR TITLE
fix(frontend): input validation and 422 error handling

### DIFF
--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -42,6 +42,8 @@ export default function RegisterPage() {
             name="username"
             type="text"
             required
+            minLength={2}
+            maxLength={100}
             className="w-full bg-gray-800 text-gray-100 border border-gray-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent placeholder:text-gray-500"
             placeholder="johndoe"
           />

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -57,7 +57,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: "Login failed" }));
-      throw new Error(error.detail || "Invalid credentials");
+      const detail = error.detail;
+      if (Array.isArray(detail)) {
+        throw new Error(detail.map((d: { msg?: string }) => d.msg || "Validation error").join(", "));
+      }
+      throw new Error(typeof detail === "string" ? detail : "Invalid credentials");
     }
 
     const data = await response.json();
@@ -86,7 +90,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: "Registration failed" }));
-      throw new Error(error.detail || "Registration failed");
+      const detail = error.detail;
+      if (Array.isArray(detail)) {
+        throw new Error(detail.map((d: { msg?: string }) => d.msg || "Validation error").join(", "));
+      }
+      throw new Error(typeof detail === "string" ? detail : "Registration failed");
     }
 
     router.push("/login");


### PR DESCRIPTION
## Summary
- 프론트엔드 회원가입 시 422 에러 발생 문제 수정
- 백엔드 유효성 검증 제약조건과 프론트엔드 입력 필드 일치시킴

### 변경사항
- `register/page.tsx`: username 입력에 `minLength=2`, `maxLength=100` 추가 (백엔드 `display_name` 제약 일치)
- `auth-context.tsx`: 422 응답의 배열 `detail`을 파싱하여 실제 에러 메시지 표시 (기존: `[object Object]`)

## Test plan
- [x] API 직접 테스트: 다양한 입력 조합으로 422 재현 확인
- [x] Playwright E2E 6개 테스트 전부 통과
- [x] 프론트엔드 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)