### PR TITLE
chore: merge develop to main - frontend fixes and use(params) bug

### DIFF
--- a/frontend/app/(main)/chat/[id]/page.tsx
+++ b/frontend/app/(main)/chat/[id]/page.tsx
@@ -1,18 +1,15 @@
 "use client";
 
-import { use } from "react";
 import ChatWindow from "@/app/components/ChatWindow";
 
 interface ChatPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 export default function ChatPage({ params }: ChatPageProps) {
-  const { id } = use(params);
-
   return (
     <div className="flex-1 overflow-hidden">
-      <ChatWindow conversationId={id} />
+      <ChatWindow conversationId={params.id} />
     </div>
   );
 }

--- a/frontend/app/(main)/templates/[id]/page.tsx
+++ b/frontend/app/(main)/templates/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { apiFetch } from "@/lib/api";
@@ -25,11 +25,11 @@ interface TemplateDetail {
 }
 
 interface TemplateDetailPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 export default function TemplateDetailPage({ params }: TemplateDetailPageProps) {
-  const { id } = use(params);
+  const { id } = params;
   const [template, setTemplate] = useState<TemplateDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isForkLoading, setIsForkLoading] = useState(false);


### PR DESCRIPTION
## Summary
PR #43 머지 이후 추가된 프론트엔드 수정사항을 포함합니다.

### 주요 변경사항
- **use(params) 런타임 에러 수정**: Next.js 14에서 `use(params)` 대신 직접 구조분해 사용 (`chat/[id]`, `templates/[id]`)
- **claude-review 지적 반영**: `fetchHistory`를 `apiFetch`로 통일, 401 후 `return` 처리, `useCallback` 의존성 안정화, `MAX_RECONNECT_ATTEMPTS` 모듈 레벨 상수화
- **5건 medium UX 버그**: Toolbar click-outside, TemplateListPanel 비동기 저장, PropertyPanel 자동 적용, Templates 에러 표시, useTemplates 캐싱
- **대화 히스토리 로딩**: 기존 대화 재진입 시 메시지 히스토리 표시
- **401 토큰 만료 처리 + WebSocket 재연결 제한**
- **New Conversation 이중 클릭 방지 + 에러 피드백**
- **422 입력 유효성 검증 개선**
- **Docker data-collector 상대 import 에러 수정**

### 커밋 목록
- `9ff8a1c` fix(frontend): replace use(params) with direct destructuring for Next.js 14
- `427c644` fix(frontend): address claude-review warnings
- `09f4ce8` fix(frontend): resolve 5 medium-priority UX bugs
- `67598c4` fix(frontend): load conversation history when reopening existing chat
- `e4a6746` fix(frontend): handle 401 expired tokens and limit WebSocket reconnects
- `0ca1459` fix(frontend): prevent double-click and show error on New Conversation button
- `8b8d025` fix(frontend): add input validation and improve 422 error handling
- `bd42ce2` fix(docker): resolve data-collector relative import error and update testing guide

## Test plan
- [x] E2E auth tests 6/6 통과
- [x] Frontend build 성공 (Docker)
- [x] Docker Compose 7 서비스 정상 기동
- [ ] CI 체크 통과 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)