### PR TITLE
chore(ci): frontend-test job, Playwright cache, BuildKit

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -33,8 +36,20 @@ jobs:
       - name: Install E2E dependencies
         run: cd e2e && npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd e2e && npx playwright install chromium --with-deps
+
+      - name: Install Playwright system deps (on cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd e2e && npx playwright install-deps chromium
 
       - name: Start services with Docker Compose
         run: cd docker && docker compose up -d --build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - run: cd frontend && npm ci && npm run build
+
+  frontend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm test


### PR DESCRIPTION
## Summary
- `test.yml`: `frontend-test` CI job 추가 (Vitest 실행)
- `e2e.yml`: Playwright 브라우저 캐시로 E2E 실행 속도 향상
- `e2e.yml`: Docker BuildKit 활성화로 이미지 빌드 최적화

> **의존성**: PR #51 머지 후 frontend-test job 정상 동작

Refs #52

## Test plan
- [ ] CI frontend-test job 실행 확인 (PR #51 머지 후)
- [ ] E2E Playwright 캐시 적중 확인
- [ ] Docker BuildKit 빌드 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)