### PR TITLE
feat(frontend): realtime pipeline monitoring with event bridge

### DIFF
--- a/frontend/app/(main)/chat/[id]/page.tsx
+++ b/frontend/app/(main)/chat/[id]/page.tsx
@@ -1,15 +1,72 @@
 "use client";
 
-import ChatWindow from "@/app/components/ChatWindow";
+import { useState, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
+import ChatWindow, { type PipelineEvent } from "@/app/components/ChatWindow";
+import SplitView from "@/app/components/SplitView";
+
+const PipelineEditor = dynamic(
+  () => import("@/app/components/pipeline-editor/PipelineEditor"),
+  { ssr: false }
+);
 
 interface ChatPageProps {
   params: { id: string };
 }
 
 export default function ChatPage({ params }: ChatPageProps) {
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [pipelineEvents, setPipelineEvents] = useState<PipelineEvent[]>([]);
+  const [editorError, setEditorError] = useState<string | null>(null);
+  const loadDesignRef = useRef<((design: Record<string, unknown>) => void) | null>(null);
+
+  const handlePipelineEvent = useCallback((event: PipelineEvent) => {
+    setPipelineEvents((prev) => [...prev, event]);
+  }, []);
+
+  const handleOpenDesign = useCallback((design: Record<string, unknown>) => {
+    setIsEditorOpen(true);
+    // Give the editor a tick to mount if it was just opened
+    setTimeout(() => {
+      loadDesignRef.current?.(design);
+    }, 0);
+  }, []);
+
+  const handleEditorReady = useCallback(
+    (loadDesign: (design: Record<string, unknown>) => void) => {
+      loadDesignRef.current = loadDesign;
+    },
+    []
+  );
+
   return (
     <div className="flex-1 overflow-hidden">
-      <ChatWindow conversationId={params.id} />
+      <SplitView
+        isEditorOpen={isEditorOpen}
+        onEditorToggle={setIsEditorOpen}
+        left={
+          <ChatWindow
+            conversationId={params.id}
+            onOpenDesign={handleOpenDesign}
+            onPipelineEvent={handlePipelineEvent}
+          />
+        }
+        right={
+          <div className="h-full flex flex-col relative">
+            {editorError && (
+              <div className="absolute top-2 left-1/2 -translate-x-1/2 z-50 bg-red-900/90 text-red-200 text-sm px-4 py-2 rounded-md border border-red-700">
+                {editorError}
+                <button onClick={() => setEditorError(null)} className="ml-2 text-red-400 hover:text-red-300">&times;</button>
+              </div>
+            )}
+            <PipelineEditor
+              onError={setEditorError}
+              onEditorReady={handleEditorReady}
+              externalPipelineEvents={pipelineEvents}
+            />
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/frontend/app/components/ChatWindow.tsx
+++ b/frontend/app/components/ChatWindow.tsx
@@ -7,9 +7,15 @@ import MessageBubble from "./MessageBubble";
 const OPEN_IN_EDITOR_MARKER = "__open_in_editor__";
 const MAX_RECONNECT_ATTEMPTS = 5;
 
+export interface PipelineEvent {
+  type: "pipeline_started" | "agent_completed" | "pipeline_result" | "pipeline_failed";
+  data: Record<string, unknown>;
+}
+
 interface ChatWindowProps {
   onOpenDesign?: (design: Record<string, unknown>) => void;
   conversationId?: string;
+  onPipelineEvent?: (event: PipelineEvent) => void;
 }
 
 interface Message {
@@ -63,7 +69,7 @@ function formatDiscussionMessage(data: Record<string, unknown>): string {
   return content;
 }
 
-export default function ChatWindow({ onOpenDesign, conversationId: propConversationId }: ChatWindowProps) {
+export default function ChatWindow({ onOpenDesign, conversationId: propConversationId, onPipelineEvent }: ChatWindowProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [isConnected, setIsConnected] = useState(false);
@@ -232,6 +238,7 @@ export default function ChatWindow({ onOpenDesign, conversationId: propConversat
           }
 
           case "pipeline_started":
+            onPipelineEvent?.({ type: "pipeline_started", data });
             setMessages((prev) => [
               ...prev,
               {
@@ -244,6 +251,7 @@ export default function ChatWindow({ onOpenDesign, conversationId: propConversat
             break;
 
           case "agent_completed":
+            onPipelineEvent?.({ type: "agent_completed", data });
             setMessages((prev) => [
               ...prev,
               {
@@ -256,6 +264,7 @@ export default function ChatWindow({ onOpenDesign, conversationId: propConversat
             break;
 
           case "pipeline_result": {
+            onPipelineEvent?.({ type: "pipeline_result", data });
             setIsTyping(false);
             const result = data.result || {};
             const output = result.output || data.content || "Pipeline completed.";
@@ -273,6 +282,7 @@ export default function ChatWindow({ onOpenDesign, conversationId: propConversat
           }
 
           case "pipeline_failed":
+            onPipelineEvent?.({ type: "pipeline_failed", data });
             setIsTyping(false);
             setMessages((prev) => [
               ...prev,

--- a/frontend/app/components/pipeline-editor/components/ProgressIndicator.tsx
+++ b/frontend/app/components/pipeline-editor/components/ProgressIndicator.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+interface ProgressIndicatorProps {
+  completedCount: number;
+  totalCount: number;
+  isRunning: boolean;
+}
+
+export default function ProgressIndicator({ completedCount, totalCount, isRunning }: ProgressIndicatorProps) {
+  if (!isRunning && completedCount === 0) return null;
+
+  const progress = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+  const isComplete = completedCount === totalCount && totalCount > 0;
+
+  return (
+    <div className="absolute bottom-4 left-4 right-4 z-20">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg p-3 shadow-lg">
+        <div className="flex items-center justify-between text-sm mb-2">
+          <span className="text-gray-300">
+            {isComplete ? "Pipeline complete" : isRunning ? "Running pipeline..." : "Pipeline finished"}
+          </span>
+          <span className="text-gray-400">
+            {completedCount}/{totalCount} agents
+          </span>
+        </div>
+        <div className="w-full bg-gray-800 rounded-full h-2">
+          <div
+            className={`h-2 rounded-full transition-all duration-500 ${
+              isComplete ? "bg-green-500" : "bg-blue-500"
+            }`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ChatWindow에 `onPipelineEvent` 콜백 prop 추가 (pipeline WS 이벤트 전달)
- chat/[id]/page.tsx에서 이벤트 상태 관리 → PipelineEditor로 전달
- PipelineEditor에 `externalPipelineEvents` prop 추가 → React Flow 노드 실시간 상태 업데이트
- ProgressIndicator 컴포넌트: "N/M agents completed" 진행률 바 표시

Refs #54

## Test plan
- [x] TypeScript 컴파일 통과 (`tsc --noEmit`)
- [x] ESLint 통과 (`next lint`)
- [ ] 채팅에서 파이프라인 실행 → React Flow 노드 색상 변화 확인
- [ ] ProgressIndicator 진행률 바 표시 확인
- [ ] CI 5개 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)