### PR TITLE
docs: update READMEs and docs for Sprint 6-7 changes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -73,6 +73,7 @@ API Gateway 레이어. HTTP/WebSocket 요청 처리, 인증/인가, 속도 제�
 - **routes/pipeline.py**: 파이프라인 실행 (직접 실행, Discussion Engine 경유)
 - **routes/templates.py**: 파이프라인 템플릿 관리 (CRUD, Fork, 공유)
 - **routes/metrics.py**: Prometheus 메트릭 엔드포인트
+- **routes/stats.py**: 사용량 통계 API (사용 이력, 파이프라인 이력)
 
 ### discussion/
 
@@ -175,6 +176,13 @@ LangGraph 기반 파이프라인 실행 엔진. Multi-LLM 라우팅, 에이전�
 |--------|------|------|
 | GET | /metrics | Prometheus 메트릭 |
 
+### Stats
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | /stats/usage-history?days=30 | 일별 사용량/비용 이력 |
+| GET | /stats/pipeline-history?limit=20 | 파이프라인 실행 이력 |
+
 ### Health
 
 | Method | Path | 설명 |
@@ -230,6 +238,24 @@ LangGraph 기반 파이프라인 실행 엔진. Multi-LLM 라우팅, 에이전�
 
 - 사용자별 일일 LLM 비용 추적 (UserDailyCost 모델)
 - 일일 한도 초과 시 429 Too Many Requests 반환
+
+## 실행 방법
+
+## 데이터베이스 마이그레이션
+
+Alembic으로 스키마를 관리합니다. Docker 환경에서는 `entrypoint.sh`가 자동으로 `alembic upgrade head`를 실행합니다.
+
+```bash
+# 마이그레이션 실행
+cd backend
+python -m alembic upgrade head
+
+# 마이그레이션 상태 확인
+python -m alembic current
+
+# 새 마이그레이션 생성
+python -m alembic revision -m "description"
+```
 
 ## 실행 방법
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -151,6 +151,13 @@ sudo chown -R $(whoami) frontend/.next
 docker compose logs backend
 ```
 
+### 데이터베이스 마이그레이션
+백엔드 컨테이너 시작 시 `entrypoint.sh`가 자동으로 `alembic upgrade head`를 실행하여 DB 스키마를 최신 상태로 유지합니다. 수동 실행이 필요한 경우:
+
+```bash
+docker compose exec backend python -m alembic -c /app/backend/alembic.ini upgrade head
+```
+
 ### DB 초기화
 데이터베이스를 완전히 초기화하려면:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,7 +137,7 @@ open http://localhost:3000
 브라우저에서 http://localhost:3000 접속 후:
 
 1. "회원가입" 버튼 클릭
-2. 이메일과 비밀번호 입력
+2. 이메일, 표시 이름(display_name), 비밀번호 입력
    - **비밀번호 요구사항**: 8자 이상, 대문자 1개 이상, 숫자 1개 이상
    - 예시: `Password123`
 3. 가입 완료 후 자동 로그인
@@ -207,7 +207,8 @@ curl -X POST http://localhost:8000/api/v1/auth/register \
   -H "Content-Type: application/json" \
   -d '{
     "email": "test@example.com",
-    "password": "Password123"
+    "password": "Password123",
+    "display_name": "테스트유저"
   }'
 ```
 
@@ -215,11 +216,13 @@ curl -X POST http://localhost:8000/api/v1/auth/register \
 ```json
 {
   "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
   "token_type": "bearer",
   "user": {
     "id": "uuid-here",
     "email": "test@example.com",
-    "role": "user"
+    "display_name": "테스트유저",
+    "role": "free"
   }
 }
 ```
@@ -244,7 +247,7 @@ curl -X POST http://localhost:8000/api/v1/auth/login \
 TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 
 # 대화 생성
-curl -X POST http://localhost:8000/api/v1/discussions/ \
+curl -X POST http://localhost:8000/api/v1/conversations \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -258,29 +261,28 @@ curl -X POST http://localhost:8000/api/v1/discussions/ \
   "id": "uuid-here",
   "title": "첫 번째 대화",
   "user_id": "user-uuid",
-  "created_at": "2024-01-15T10:30:00Z",
-  "updated_at": "2024-01-15T10:30:00Z"
+  "created_at": "2024-01-15T10:30:00Z"
 }
 ```
 
-### 파이프라인 생성 (인증 필요)
+### 파이프라인 직접 실행 (인증 필요)
 
 ```bash
-curl -X POST http://localhost:8000/api/v1/pipelines/ \
+curl -X POST http://localhost:8000/api/v1/pipelines/execute-direct \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "간단한 분석 파이프라인",
-    "description": "프롬프트 분석 후 설계 생성",
-    "config": {
-      "nodes": [
-        {"id": "1", "type": "analyzer", "config": {}},
-        {"id": "2", "type": "designer", "config": {}}
+    "design": {
+      "design_name": "간단한 분석 파이프라인",
+      "agents": [
+        {"name": "analyzer", "role": "intent_analyzer", "model_hint": "auto"},
+        {"name": "designer", "role": "design_generator", "model_hint": "auto"}
       ],
       "edges": [
-        {"from": "1", "to": "2"}
+        {"from_agent": "analyzer", "to_agent": "designer"}
       ]
-    }
+    },
+    "user_prompt": "Python으로 간단한 웹 크롤러를 만들어줘"
   }'
 ```
 
@@ -511,9 +513,10 @@ docker compose exec redis redis-cli
 AgentForge를 성공적으로 실행했다면:
 
 1. **API 문서 확인**: http://localhost:8000/docs (Swagger UI)
-2. **아키텍처 이해**: `docs/phase-*.md` 문서 읽기
-3. **테스트 실행**: `pytest tests/` 로컬 테스트 실행
-4. **개발 모드**: Phase 8 개발자 고급 모드 활성화
+2. **대시보드 확인**: http://localhost:3000/dashboard (사용량 차트, 파이프라인 이력)
+3. **아키텍처 이해**: `docs/phase-*.md` 문서 읽기
+4. **테스트 실행**: `cd backend && python -m pytest ../tests/ -v` 로컬 테스트 실행
+5. **파이프라인 에디터**: React Flow 기반 시각적 파이프라인 편집기 사용
 
 문제가 발생하면 GitHub Issues에 등록해주세요:
 https://github.com/Maroco0109/AgentForge/issues

--- a/docs/phase-08a-react-flow-editor.md
+++ b/docs/phase-08a-react-flow-editor.md
@@ -56,7 +56,7 @@ React Flow 기반 시각적 파이프라인 에디터를 추가하여 사용자�
 
 - React Flow v11 사용 (v12는 React 19 필요, 프로젝트는 React 18.3.1)
 - 동시 편집 미지원 (last-write-wins + `updated_at`)
-- 프론트엔드는 TypeScript 컴파일 + ESLint로 검증 (런타임 테스트 없음)
+- 프론트엔드는 TypeScript 컴파일 + ESLint + Vitest 단위 테스트(43개)로 검증
 
 ## 다음 단계 (Phase 8B)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -64,7 +64,8 @@ e2e/
 ├── playwright.config.ts    # Playwright 설정
 ├── package.json            # 의존성 및 스크립트
 ├── tests/
-│   ├── helpers.ts          # 공통 헬퍼 함수 (인증, 사용자 생성 등)
+│   ├── helpers.ts          # 공통 헬퍼 함수 (인증, 사용자 생성, 템플릿 생성 등)
+│   ├── smoke.spec.ts       # 스모크 테스트 (서비스 가용성)
 │   ├── auth.spec.ts        # 인증 관련 테스트
 │   ├── chat.spec.ts        # 채팅 기능 테스트
 │   ├── pipeline-editor.spec.ts  # 파이프라인 에디터 테스트
@@ -72,7 +73,16 @@ e2e/
 └── README.md
 ```
 
+## 테스트 현황
+
+- **활성 테스트**: 13개
+- **스킵된 테스트**: 6개 (WebSocket/LLM 의존, 저장 다이얼로그 플로우 불일치)
+
 ## 테스트 범위
+
+### smoke.spec.ts
+- 프론트엔드 접속 가능 확인
+- 백엔드 헬스체크 확인
 
 ### auth.spec.ts
 - 회원가입 페이지 렌더링
@@ -114,6 +124,8 @@ e2e/
 - `loginUser(request, user)`: API를 통한 로그인 및 JWT 토큰 반환
 - `authenticatedContext(browser, token)`: JWT 인증된 브라우저 컨텍스트 생성
 - `createConversation(request, token, title)`: API를 통한 대화 생성
+- `createTemplate(request, token, name, description)`: API를 통한 템플릿 생성
+- `shareTemplate(request, token, templateId)`: API를 통한 템플릿 공개 설정
 
 ## CI/CD 통합
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,13 @@ AgentForge 멀티 에이전트 플랫폼의 프론트엔드 애플리케이션�
 
 - **app/page.tsx**: 루트 페이지 (SplitView: 채팅 + 파이프라인 에디터 토글)
 - **app/layout.tsx**: 루트 레이아웃 (lang="ko", Tailwind globals.css 적용)
+- **app/(auth)/login/page.tsx**: 로그인 페이지
+- **app/(auth)/register/page.tsx**: 회원가입 페이지
+- **app/(main)/conversations/page.tsx**: 대화 목록
+- **app/(main)/conversations/[id]/page.tsx**: 대화 상세 (채팅)
+- **app/(main)/templates/page.tsx**: 템플릿 목록/검색
+- **app/(main)/templates/[id]/page.tsx**: 템플릿 상세/포크
+- **app/(main)/dashboard/page.tsx**: 사용자 대시보드 (사용량 차트, 비용 차트, 파이프라인 이력)
 
 ## 주요 컴포넌트
 
@@ -38,6 +45,14 @@ AgentForge 멀티 에이전트 플랫폼의 프론트엔드 애플리케이션�
 - **pipeline-editor/panels/TemplateListPanel.tsx**: 템플릿 관리
   - 저장/불러오기/포크/공유 기능
 - **pipeline-editor/panels/Toolbar.tsx**: 노드 추가/실행/저장/불러오기/초기화
+- **pipeline-editor/components/ProgressIndicator.tsx**: 파이프라인 실행 진행률 표시 ("2/5 agents completed")
+
+### 대시보드
+
+- **dashboard/page.tsx**: 대시보드 메인 페이지
+- **dashboard/components/UsageChart.tsx**: 일별 사용량 LineChart (recharts)
+- **dashboard/components/CostChart.tsx**: 일별 비용 BarChart (recharts)
+- **dashboard/components/PipelineHistory.tsx**: 파이프라인 실행 이력 테이블
 
 ### 커스텀 훅
 
@@ -97,10 +112,17 @@ REST API fetch wrapper
 - 에러 핸들링
 - JSON 응답 파싱
 
+### lib/auth-context.tsx
+인증 컨텍스트 (React Context)
+
+- `AuthProvider`: 인증 상태 관리 (login, logout, register)
+- `useAuth()`: 인증 상태 접근 훅 (user, isAuthenticated, loading)
+- localStorage 기반 토큰 관리 (`agentforge_access_token`, `agentforge_refresh_token`)
+
 ### lib/auth.ts
 인증 함수
 
-- `register(email, password)`: 회원가입
+- `register(email, password, display_name)`: 회원가입
 - `login(email, password)`: 로그인 (accessToken, refreshToken 반환)
 - `refresh(refreshToken)`: 토큰 갱신
 - `getMe(accessToken)`: 사용자 정보 조회
@@ -123,9 +145,12 @@ REST API fetch wrapper
 | `react` | 18.3.1 | UI 라이브러리 |
 | `react-dom` | 18.3.1 | React DOM 렌더러 |
 | `reactflow` | 11.11.4 | 파이프라인 에디터 |
+| `recharts` | ^3.7.0 | 대시보드 차트 (LineChart, BarChart) |
 | `tailwindcss` | 3.4.1 | CSS 프레임워크 |
 | `typescript` | 5.x | 타입 체킹 |
 | `eslint` | 8.x | 린팅 |
+| `vitest` | (dev) | 단위 테스트 프레임워크 |
+| `@testing-library/react` | (dev) | React 컴포넌트 테스트 |
 
 ## 실행 방법
 
@@ -145,6 +170,16 @@ npm run build
 npm start
 ```
 
+### 단위 테스트
+
+```bash
+npm test           # vitest run (CI용)
+npx vitest         # watch 모드 (개발용)
+npx vitest --ui    # UI 모드
+```
+
+43개 단위 테스트: API 클라이언트, 인증 컨텍스트, 페이지 컴포넌트, 훅 등
+
 ### 린트
 
 ```bash
@@ -158,6 +193,15 @@ ESLint를 실행하여 코드 스타일을 검사합니다.
 ```
 frontend/
 ├── app/
+│   ├── (auth)/                      # 인증 페이지
+│   │   ├── login/page.tsx           # 로그인
+│   │   └── register/page.tsx        # 회원가입
+│   ├── (main)/                      # 메인 페이지 (인증 필요)
+│   │   ├── conversations/           # 대화 목록/상세
+│   │   ├── dashboard/               # 사용자 대시보드
+│   │   │   ├── page.tsx             # 대시보드 메인
+│   │   │   └── components/          # UsageChart, CostChart, PipelineHistory
+│   │   └── templates/               # 템플릿 목록/상세/포크
 │   ├── components/
 │   │   ├── ChatWindow.tsx           # WebSocket 채팅
 │   │   ├── MessageBubble.tsx        # 메시지 렌더링
@@ -170,6 +214,8 @@ frontend/
 │   │       │   ├── PropertyPanel.tsx      # 속성 편집
 │   │       │   ├── TemplateListPanel.tsx  # 템플릿 관리
 │   │       │   └── Toolbar.tsx            # 도구 모음
+│   │       ├── components/
+│   │       │   └── ProgressIndicator.tsx  # 실행 진행률
 │   │       ├── hooks/
 │   │       │   ├── useFlowState.ts        # Flow 상태
 │   │       │   ├── usePipelineExecution.ts # 실행 제어
@@ -184,8 +230,11 @@ frontend/
 ├── lib/
 │   ├── websocket.ts                 # WebSocket 클라이언트
 │   ├── api.ts                       # REST API wrapper
-│   └── auth.ts                      # 인증 함수
+│   ├── auth.ts                      # 인증 함수
+│   └── auth-context.tsx             # 인증 컨텍스트 (React Context)
 ├── public/                          # 정적 파일
+├── vitest.config.ts                 # Vitest 테스트 설정
+├── vitest.setup.ts                  # 테스트 셋업 (jest-dom)
 ├── .env.local                       # 환경변수 (git ignore)
 ├── next.config.js                   # Next.js 설정
 ├── tailwind.config.ts               # Tailwind 설정
@@ -200,4 +249,6 @@ frontend/
 - **TypeScript**: 정적 타입 체킹
 - **Tailwind CSS**: 유틸리티 우선 CSS 프레임워크
 - **React Flow**: 노드 기반 다이어그램 라이브러리
+- **Recharts**: 차트 라이브러리 (대시보드)
+- **Vitest + React Testing Library**: 단위 테스트 (43개)
 - **WebSocket API**: 실시간 통신


### PR DESCRIPTION
## Summary

Sprint 6-7 (E2E 활성화, Vitest 설정, Alembic 전환, CI 캐시, Dashboard, Pipeline Monitoring) 완료 후 문서/README 업데이트.

- **README.md**: CI 7개 체크 테이블 (frontend-test 추가), 프로젝트 구조 업데이트 (dashboard, stats, vitest, auth-context, entrypoint, E2E 파일)
- **backend/README.md**: Stats API 라우트 추가, Alembic 마이그레이션 섹션 추가
- **frontend/README.md**: Dashboard 페이지, recharts, ProgressIndicator, Vitest 테스트, auth-context, 디렉토리 구조 업데이트
- **e2e/README.md**: 테스트 현황 (13 active/6 skipped), smoke.spec.ts, 헬퍼 함수 추가
- **docker/README.md**: Alembic 마이그레이션 자동 실행 설명 추가
- **docs/getting-started.md**: display_name 필드, /conversations API 경로 수정, 응답 포맷 수정, 대시보드 링크
- **docs/phase-08a-react-flow-editor.md**: Vitest 단위 테스트(43개) 검증 상태 반영

## Test plan

- [ ] 문서 내 API 경로가 실제 코드와 일치하는지 확인
- [ ] 프로젝트 구조가 실제 파일 시스템과 일치하는지 확인
- [ ] CI 7개 체크 전부 통과 확인

Refs #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)