### PR TITLE
Sprint 9-3: Pydantic v2 Config Migration

### DIFF
--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -1,7 +1,7 @@
 """Application configuration using Pydantic Settings."""
 
 from pydantic import model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -41,11 +41,7 @@ class Settings(BaseSettings):
                 raise ValueError("SECRET_KEY must be set in production")
         return self
 
-    class Config:
-        """Pydantic config."""
-
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 settings = Settings()

--- a/backend/shared/schemas.py
+++ b/backend/shared/schemas.py
@@ -30,10 +30,7 @@ class UserResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 # Conversation schemas
@@ -53,10 +50,7 @@ class ConversationResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 class ConversationDetailResponse(ConversationResponse):
@@ -64,10 +58,7 @@ class ConversationDetailResponse(ConversationResponse):
 
     messages: list["MessageResponse"]
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 # Message schemas
@@ -90,10 +81,7 @@ class MessageResponse(BaseModel):
     metadata_: dict | None
     created_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 # WebSocket schemas
@@ -123,10 +111,7 @@ class APIKeyResponse(BaseModel):
     last_used_at: datetime | None
     created_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 class APIKeyCreateResponse(APIKeyResponse):
@@ -215,10 +200,7 @@ class TemplateResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 class TemplateListResponse(BaseModel):
@@ -231,10 +213,7 @@ class TemplateListResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 # LLM Key schemas (BYOK)
@@ -258,10 +237,7 @@ class LLMKeyResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        """Pydantic config."""
-
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 class LLMKeyValidationResponse(BaseModel):

--- a/data-collector/config.py
+++ b/data-collector/config.py
@@ -1,6 +1,6 @@
 """Data Collector configuration."""
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class CollectorSettings(BaseSettings):
@@ -12,9 +12,7 @@ class CollectorSettings(BaseSettings):
     MAX_COLLECTION_SIZE_MB: int = 100
     PII_DETECTION_ENABLED: bool = True
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 collector_settings = CollectorSettings()


### PR DESCRIPTION
## Summary
- deprecated `class Config` 내부 클래스를 Pydantic v2 `model_config` 딕셔너리로 마이그레이션
- `backend/shared/schemas.py`: 8개 모델 클래스 마이그레이션
- `backend/shared/config.py`: `SettingsConfigDict` 적용
- `data-collector/config.py`: 동일 패턴 적용

## Changes
- **MODIFY** `backend/shared/schemas.py` — 8개 `class Config` → `model_config = {"from_attributes": True}`
- **MODIFY** `backend/shared/config.py` — `SettingsConfigDict(env_file=".env", ...)`
- **MODIFY** `data-collector/config.py` — 동일 패턴

## Test plan
- [x] 기존 651개 전체 테스트 통과 (회귀 검증)
- [x] ruff format + check 통과

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)