### PR TITLE
Sprint 9-4: Frontend Token Refresh Interceptor

### DIFF
--- a/frontend/lib/__tests__/api.test.ts
+++ b/frontend/lib/__tests__/api.test.ts
@@ -1,14 +1,31 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiFetch } from '../api';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-describe('apiFetch', () => {
+// Mock auth module BEFORE importing api
+vi.mock("../auth", () => ({
+  getAccessToken: vi.fn(() => null),
+  getRefreshTokenFromStorage: vi.fn(() => null),
+  refreshToken: vi.fn(),
+  saveTokens: vi.fn(),
+  clearTokens: vi.fn(),
+}));
+
+import { apiFetch, _resetRefreshState } from "../api";
+import * as authModule from "../auth";
+
+describe("apiFetch", () => {
   const originalFetch = global.fetch;
-  const originalLocation = window.location;
 
   beforeEach(() => {
-    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
-    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {});
+    vi.clearAllMocks();
+    _resetRefreshState();
     global.fetch = vi.fn();
+    vi.mocked(authModule.getAccessToken).mockReturnValue(null);
+    vi.mocked(authModule.getRefreshTokenFromStorage).mockReturnValue(null);
+    // Reset window.location
+    delete (window as unknown as { location?: unknown }).location;
+    (window as unknown as { location: { href: string } }).location = {
+      href: "",
+    };
   });
 
   afterEach(() => {
@@ -16,104 +33,217 @@ describe('apiFetch', () => {
     global.fetch = originalFetch;
   });
 
-  it('returns parsed JSON on successful GET request (200)', async () => {
-    const mockData = { id: '1', name: 'Test' };
+  it("returns parsed JSON on successful GET request (200)", async () => {
+    const mockData = { id: "1", name: "Test" };
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => mockData,
     });
 
-    const result = await apiFetch<typeof mockData>('/api/v1/test');
+    const result = await apiFetch<typeof mockData>("/api/v1/test");
     expect(result).toEqual(mockData);
   });
 
-  it('handles 401 unauthorized: clears token and redirects', async () => {
-    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('old-token');
-    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
-    // jsdom allows assignment to window.location.href
-    delete (window as unknown as { location?: unknown }).location;
-    (window as unknown as { location: { href: string } }).location = { href: '' };
-
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      status: 401,
-      json: async () => ({ detail: 'Unauthorized' }),
-      statusText: 'Unauthorized',
-    });
-
-    const result = await apiFetch<null>('/api/v1/protected');
-    expect(removeItemSpy).toHaveBeenCalledWith('access_token');
-    expect((window as unknown as { location: { href: string } }).location.href).toBe('/login');
-    expect(result).toBeUndefined();
-  });
-
-  it('handles 422 validation error with array detail', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      status: 422,
-      statusText: 'Unprocessable Entity',
-      json: async () => ({ detail: [{ msg: 'field required' }, { msg: 'invalid email' }] }),
-    });
-
-    await expect(apiFetch('/api/v1/test')).rejects.toThrow('field required, invalid email');
-  });
-
-  it('handles 204 no content and returns undefined', async () => {
+  it("handles 204 no content and returns undefined", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       status: 204,
-      json: async () => { throw new Error('no body'); },
+      json: async () => {
+        throw new Error("no body");
+      },
     });
 
-    const result = await apiFetch<void>('/api/v1/test');
+    const result = await apiFetch<void>("/api/v1/test");
     expect(result).toBeUndefined();
   });
 
-  it('handles network error (fetch throws)', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network Error'));
-
-    await expect(apiFetch('/api/v1/test')).rejects.toThrow('Network Error');
+  it("handles network error (fetch throws)", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Network Error")
+    );
+    await expect(apiFetch("/api/v1/test")).rejects.toThrow("Network Error");
   });
 
-  it('sends Authorization header when token exists in localStorage', async () => {
-    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('my-jwt-token');
+  it("sends Authorization header when token exists", async () => {
+    vi.mocked(authModule.getAccessToken).mockReturnValue("my-jwt-token");
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => ({}),
     });
 
-    await apiFetch('/api/v1/test');
+    await apiFetch("/api/v1/test");
 
     const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     const headers = callArgs[1].headers;
-    expect(headers['Authorization']).toBe('Bearer my-jwt-token');
+    expect(headers["Authorization"]).toBe("Bearer my-jwt-token");
   });
 
-  it('does not send Authorization header when no token in localStorage', async () => {
-    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+  it("does not send Authorization header when no token", async () => {
+    vi.mocked(authModule.getAccessToken).mockReturnValue(null);
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => ({}),
     });
 
-    await apiFetch('/api/v1/test');
+    await apiFetch("/api/v1/test");
 
     const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     const headers = callArgs[1].headers;
-    expect(headers['Authorization']).toBeUndefined();
+    expect(headers["Authorization"]).toBeUndefined();
   });
 
-  it('handles non-array string detail error gracefully', async () => {
+  it("handles 422 validation error with array detail", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: async () => ({
+        detail: [{ msg: "field required" }, { msg: "invalid email" }],
+      }),
+    });
+
+    await expect(apiFetch("/api/v1/test")).rejects.toThrow(
+      "field required, invalid email"
+    );
+  });
+
+  it("handles non-array string detail error gracefully", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: false,
       status: 400,
-      statusText: 'Bad Request',
-      json: async () => ({ detail: 'Something went wrong' }),
+      statusText: "Bad Request",
+      json: async () => ({ detail: "Something went wrong" }),
     });
 
-    await expect(apiFetch('/api/v1/test')).rejects.toThrow('Something went wrong');
+    await expect(apiFetch("/api/v1/test")).rejects.toThrow(
+      "Something went wrong"
+    );
+  });
+
+  // Token Refresh Tests
+  describe("token refresh on 401", () => {
+    it("redirects to login when no refresh token available", async () => {
+      vi.mocked(authModule.getRefreshTokenFromStorage).mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ detail: "Unauthorized" }),
+      });
+
+      await apiFetch("/api/v1/protected");
+      expect(authModule.clearTokens).toHaveBeenCalled();
+      expect(window.location.href).toBe("/login");
+    });
+
+    it("refreshes token and retries on 401", async () => {
+      vi.mocked(authModule.getRefreshTokenFromStorage).mockReturnValue(
+        "valid-refresh"
+      );
+      vi.mocked(authModule.refreshToken).mockResolvedValueOnce({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        token_type: "bearer",
+      });
+      vi.mocked(authModule.getAccessToken)
+        .mockReturnValueOnce("old-token")
+        .mockReturnValueOnce("new-access");
+
+      const mockData = { id: "1" };
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          json: async () => ({ detail: "Token expired" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockData,
+        });
+
+      const result = await apiFetch("/api/v1/protected");
+      expect(authModule.refreshToken).toHaveBeenCalledWith("valid-refresh");
+      expect(authModule.saveTokens).toHaveBeenCalled();
+      expect(result).toEqual(mockData);
+    });
+
+    it("does not retry refresh on /auth/refresh endpoint (infinite loop prevention)", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ detail: "Unauthorized" }),
+      });
+
+      await apiFetch("/api/v1/auth/refresh");
+      expect(authModule.clearTokens).toHaveBeenCalled();
+      expect(window.location.href).toBe("/login");
+      expect(authModule.refreshToken).not.toHaveBeenCalled();
+    });
+
+    it("logs out when refresh fails", async () => {
+      vi.mocked(authModule.getRefreshTokenFromStorage).mockReturnValue(
+        "expired-refresh"
+      );
+      vi.mocked(authModule.refreshToken).mockRejectedValueOnce(
+        new Error("Refresh failed")
+      );
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ detail: "Token expired" }),
+      });
+
+      await apiFetch("/api/v1/protected");
+      expect(authModule.clearTokens).toHaveBeenCalled();
+      expect(window.location.href).toBe("/login");
+    });
+
+    it("handles concurrent 401s with single refresh (mutex)", async () => {
+      vi.mocked(authModule.getRefreshTokenFromStorage).mockReturnValue(
+        "valid-refresh"
+      );
+      vi.mocked(authModule.refreshToken).mockResolvedValueOnce({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        token_type: "bearer",
+      });
+      vi.mocked(authModule.getAccessToken).mockReturnValue("new-access");
+
+      const make401 = () => ({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ detail: "Token expired" }),
+      });
+
+      const makeOk = () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: "ok" }),
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(make401())
+        .mockResolvedValueOnce(make401())
+        .mockResolvedValueOnce(makeOk())
+        .mockResolvedValueOnce(makeOk());
+
+      const [r1, r2] = await Promise.all([
+        apiFetch("/api/v1/endpoint1"),
+        apiFetch("/api/v1/endpoint2"),
+      ]);
+
+      expect(authModule.refreshToken).toHaveBeenCalledTimes(1);
+      expect(r1).toEqual({ data: "ok" });
+      expect(r2).toEqual({ data: "ok" });
+    });
   });
 });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -70,7 +70,7 @@ export async function apiFetch<T>(
     // Handle 401 Unauthorized with token refresh
     if (response.status === 401 && typeof window !== "undefined") {
       // Don't try to refresh if we're already on the refresh endpoint (infinite loop prevention)
-      if (path.includes("/auth/refresh")) {
+      if (path.endsWith("/auth/refresh")) {
         clearTokens();
         window.location.href = "/login";
         return undefined as T;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -27,7 +27,8 @@ async function tryRefresh(): Promise<string | null> {
     const tokens = await refreshToken(refresh);
     saveTokens(tokens);
     return tokens.access_token;
-  } catch {
+  } catch (err) {
+    console.warn("[apiFetch] Token refresh failed:", err);
     return null;
   }
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,12 +1,49 @@
-// REST API fetch wrapper with JWT authentication
+// REST API fetch wrapper with JWT authentication and auto token refresh
+
+import {
+  refreshToken,
+  saveTokens,
+  getRefreshTokenFromStorage,
+  clearTokens,
+  getAccessToken,
+} from "./auth";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+// Mutex to prevent concurrent refresh attempts
+let isRefreshing = false;
+let refreshPromise: Promise<string | null> | null = null;
+
+// Test-only helper to reset module-level state between tests
+export function _resetRefreshState(): void {
+  isRefreshing = false;
+  refreshPromise = null;
+}
+
+async function tryRefresh(): Promise<string | null> {
+  const refresh = getRefreshTokenFromStorage();
+  if (!refresh) return null;
+  try {
+    const tokens = await refreshToken(refresh);
+    saveTokens(tokens);
+    return tokens.access_token;
+  } catch {
+    return null;
+  }
+}
+
+async function refreshOrWait(): Promise<string | null> {
+  if (isRefreshing && refreshPromise) return refreshPromise;
+  isRefreshing = true;
+  refreshPromise = tryRefresh().finally(() => {
+    isRefreshing = false;
+    refreshPromise = null;
+  });
+  return refreshPromise;
+}
+
 function getAuthHeaders(): Record<string, string> {
-  const token =
-    typeof window !== "undefined"
-      ? localStorage.getItem("access_token")
-      : null;
+  const token = getAccessToken();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
@@ -30,19 +67,79 @@ export async function apiFetch<T>(
   });
 
   if (!response.ok) {
-    // Clear expired/invalid token and redirect to login on 401
+    // Handle 401 Unauthorized with token refresh
     if (response.status === 401 && typeof window !== "undefined") {
-      localStorage.removeItem("access_token");
+      // Don't try to refresh if we're already on the refresh endpoint (infinite loop prevention)
+      if (path.includes("/auth/refresh")) {
+        clearTokens();
+        window.location.href = "/login";
+        return undefined as T;
+      }
+
+      // Try to refresh the token
+      const newToken = await refreshOrWait();
+      if (newToken) {
+        // Retry original request with new token
+        const retryResponse = await fetch(url, {
+          ...options,
+          headers: {
+            ...getAuthHeaders(),
+            ...(options.headers || {}),
+          },
+        });
+
+        if (retryResponse.ok) {
+          if (retryResponse.status === 204) {
+            return undefined as T;
+          }
+          return retryResponse.json();
+        }
+
+        // Retry also failed — check if it's another 401
+        if (retryResponse.status === 401) {
+          clearTokens();
+          window.location.href = "/login";
+          return undefined as T;
+        }
+
+        const retryError = await retryResponse
+          .json()
+          .catch(() => ({ detail: retryResponse.statusText }));
+        const retryDetail = retryError.detail;
+        if (Array.isArray(retryDetail)) {
+          throw new Error(
+            retryDetail
+              .map((d: { msg?: string }) => d.msg || "Validation error")
+              .join(", ")
+          );
+        }
+        throw new Error(
+          typeof retryDetail === "string"
+            ? retryDetail
+            : `API error: ${retryResponse.status}`
+        );
+      }
+
+      // Refresh failed — logout
+      clearTokens();
       window.location.href = "/login";
       return undefined as T;
     }
 
-    const error = await response.json().catch(() => ({ detail: response.statusText }));
+    const error = await response
+      .json()
+      .catch(() => ({ detail: response.statusText }));
     const detail = error.detail;
     if (Array.isArray(detail)) {
-      throw new Error(detail.map((d: { msg?: string }) => d.msg || "Validation error").join(", "));
+      throw new Error(
+        detail
+          .map((d: { msg?: string }) => d.msg || "Validation error")
+          .join(", ")
+      );
     }
-    throw new Error(typeof detail === "string" ? detail : `API error: ${response.status}`);
+    throw new Error(
+      typeof detail === "string" ? detail : `API error: ${response.status}`
+    );
   }
 
   if (response.status === 204) {
@@ -76,7 +173,10 @@ export async function listLLMKeys(): Promise<LLMKeyResponse[]> {
   return apiFetch<LLMKeyResponse[]>("/api/v1/llm-keys");
 }
 
-export async function registerLLMKey(provider: string, apiKey: string): Promise<LLMKeyResponse> {
+export async function registerLLMKey(
+  provider: string,
+  apiKey: string
+): Promise<LLMKeyResponse> {
   return apiFetch<LLMKeyResponse>("/api/v1/llm-keys", {
     method: "POST",
     body: JSON.stringify({ provider, api_key: apiKey }),
@@ -87,8 +187,13 @@ export async function deleteLLMKey(keyId: string): Promise<void> {
   await apiFetch<void>(`/api/v1/llm-keys/${keyId}`, { method: "DELETE" });
 }
 
-export async function validateLLMKey(keyId: string): Promise<LLMKeyValidationResponse> {
-  return apiFetch<LLMKeyValidationResponse>(`/api/v1/llm-keys/${keyId}/validate`, {
-    method: "POST",
-  });
+export async function validateLLMKey(
+  keyId: string
+): Promise<LLMKeyValidationResponse> {
+  return apiFetch<LLMKeyValidationResponse>(
+    `/api/v1/llm-keys/${keyId}/validate`,
+    {
+      method: "POST",
+    }
+  );
 }

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import { saveTokens, clearTokens } from "./auth";
 
 interface User {
   email: string;
@@ -67,7 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const data = await response.json();
     const accessToken = data.access_token;
 
-    localStorage.setItem(TOKEN_KEY, accessToken);
+    saveTokens(data);
     setToken(accessToken);
 
     // Decode user info from JWT
@@ -101,7 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [router]);
 
   const logout = useCallback(() => {
-    localStorage.removeItem(TOKEN_KEY);
+    clearTokens();
     setToken(null);
     setUser(null);
     router.push("/login");


### PR DESCRIPTION
## Summary
- `apiFetch`에 401 → 자동 토큰 갱신 → 원래 요청 재시도 로직 추가
- `auth.ts` 헬퍼 재사용 (refreshToken, saveTokens, clearTokens, getAccessToken)
- Mutex로 동시 refresh 방지 (concurrent 401 대응)
- `/auth/refresh` 엔드포인트 자체 401 시 무한 루프 방지
- `auth-context.tsx`도 auth.ts 헬퍼로 통합 (중복 localStorage 접근 제거)

## Changes
- **MODIFY** `frontend/lib/api.ts` — token refresh interceptor + mutex
- **MODIFY** `frontend/lib/auth-context.tsx` — saveTokens/clearTokens 재사용
- **MODIFY** `frontend/lib/__tests__/api.test.ts` — 12개 테스트 (refresh 시나리오 5개 추가)

## Test plan
- [x] 200/204/네트워크 에러 기본 동작
- [x] Authorization 헤더 전송/미전송
- [x] 401 → refresh 없을 때 로그인 리다이렉트
- [x] 401 → refresh 성공 → 원래 요청 재시도 성공
- [x] /auth/refresh 엔드포인트에서 401 시 refresh 재시도 안 함
- [x] refresh 실패 시 로그아웃
- [x] concurrent 401 → 하나의 refresh만 실행 (mutex)

Refs #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)