### PR TITLE
Sprint 9-5: CORS Tightening

### DIFF
--- a/backend/gateway/main.py
+++ b/backend/gateway/main.py
@@ -49,7 +49,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     allow_headers=["Content-Type", "Authorization", "X-API-Key"],
     expose_headers=["Retry-After"],
 )

--- a/backend/gateway/main.py
+++ b/backend/gateway/main.py
@@ -49,8 +49,9 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+    expose_headers=["Retry-After"],
 )
 
 # Prometheus metrics middleware

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,0 +1,87 @@
+"""Tests for CORS configuration."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.gateway.main import app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    """Async test client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.anyio
+async def test_cors_allows_get_method(client):
+    """GET method should be allowed."""
+    response = await client.options(
+        "/api/v1/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    allowed = response.headers.get("access-control-allow-methods", "")
+    assert "GET" in allowed
+
+
+@pytest.mark.anyio
+async def test_cors_allows_post_method(client):
+    """POST method should be allowed."""
+    response = await client.options(
+        "/api/v1/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    allowed = response.headers.get("access-control-allow-methods", "")
+    assert "POST" in allowed
+
+
+@pytest.mark.anyio
+async def test_cors_allows_delete_method(client):
+    """DELETE method should be allowed."""
+    response = await client.options(
+        "/api/v1/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "DELETE",
+        },
+    )
+    allowed = response.headers.get("access-control-allow-methods", "")
+    assert "DELETE" in allowed
+
+
+@pytest.mark.anyio
+async def test_cors_allows_required_headers(client):
+    """Authorization and X-API-Key headers should be allowed."""
+    response = await client.options(
+        "/api/v1/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization, X-API-Key",
+        },
+    )
+    allowed = response.headers.get("access-control-allow-headers", "")
+    assert "Authorization" in allowed or "authorization" in allowed
+
+
+@pytest.mark.anyio
+async def test_cors_exposes_retry_after(client):
+    """Retry-After header should be exposed to the browser."""
+    response = await client.get(
+        "/api/v1/health",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    exposed = response.headers.get("access-control-expose-headers", "")
+    assert "Retry-After" in exposed or "retry-after" in exposed.lower()


### PR DESCRIPTION
## Summary
- CORS `allow_methods=["*"]` → `["GET", "POST", "PUT", "DELETE"]` 명시적 제한
- CORS `allow_headers=["*"]` → `["Content-Type", "Authorization", "X-API-Key"]` 명시적 제한
- `expose_headers=["Retry-After"]` 추가 (rate limit 429 응답에서 프론트엔드가 읽어야 함)

## Changes
- **MODIFY** `backend/gateway/main.py` — CORS 설정 강화
- **NEW** `tests/unit/test_cors.py` — 5개 테스트

## Test plan
- [x] GET/POST/DELETE 메서드 허용 확인
- [x] Authorization, X-API-Key 헤더 허용 확인
- [x] Retry-After expose 확인

## 의존성
Phase 9-1과 같은 `main.py` 수정하지만 다른 라인 (CORS 설정 vs 미들웨어/핸들러). Git auto-merge 가능.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)