### PR TITLE
chore(k8s): K8s deployment manifests (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ logs/
 
 # OMC State
 .omc/
+
+# K8s secrets (never commit actual secrets)
+k8s/secrets.yaml
+k8s/monitoring/monitoring-secret.yaml

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     # Encryption
     ENCRYPTION_KEY: str = ""
 
+    # Database pool settings (K8s optimized)
+    DB_POOL_SIZE: int = 5
+    DB_MAX_OVERFLOW: int = 10
+
     @model_validator(mode="after")
     def validate_secret_key(self):
         """Provide default SECRET_KEY in debug mode, require it in production."""

--- a/backend/shared/database.py
+++ b/backend/shared/database.py
@@ -17,6 +17,10 @@ engine: AsyncEngine = create_async_engine(
     settings.DATABASE_URL,
     echo=settings.DEBUG,
     future=True,
+    pool_size=settings.DB_POOL_SIZE,
+    max_overflow=settings.DB_MAX_OVERFLOW,
+    pool_recycle=3600,
+    pool_pre_ping=True,
 )
 
 # Create async session maker

--- a/docker/Dockerfile.backend.prod
+++ b/docker/Dockerfile.backend.prod
@@ -38,10 +38,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')" || exit 1
 
 CMD ["gunicorn", "gateway.main:app", \
-     "-w", "4", \
+     "-w", "1", \
      "-k", "uvicorn.workers.UvicornWorker", \
      "--bind", "0.0.0.0:8000", \
      "--timeout", "120", \
      "--graceful-timeout", "30", \
      "--max-requests", "1000", \
-     "--max-requests-jitter", "50"]
+     "--max-requests-jitter", "50", \
+     "--ws-max-size", "1048576"]

--- a/docker/Dockerfile.collector.prod
+++ b/docker/Dockerfile.collector.prod
@@ -35,7 +35,7 @@ USER appuser
 EXPOSE 8001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/api/v1/health')" || exit 1
 
 CMD ["gunicorn", "main:app", \
      "-w", "2", \

--- a/docs/sprint-10-k8s.md
+++ b/docs/sprint-10-k8s.md
@@ -1,0 +1,160 @@
+# Sprint 10: Kubernetes 배포 매니페스트
+
+## 개요
+
+Docker Compose 기반 AgentForge 7개 서비스를 Kubernetes 클러스터에서 실행할 수 있도록 매니페스트를 작성하고, 필요한 코드 수정을 수행했다.
+
+## K8s 아키텍처
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  NGINX Ingress                       │
+│         (cookie affinity, WebSocket support)         │
+├─────────────┬───────────────┬───────────────────────┤
+│   /         │   /api/       │   /ws/                │
+│   ↓         │   ↓           │   ↓                   │
+│ frontend:3000│ backend:8000 │ backend:8000          │
+│ (2 replicas)│ (2-5, HPA)   │ (workers=1, WS safe)  │
+├─────────────┴───────────────┴───────────────────────┤
+│                  NetworkPolicy                       │
+├──────────────────┬──────────────────────────────────┤
+│  PostgreSQL      │  Redis                           │
+│  StatefulSet     │  StatefulSet                     │
+│  (10Gi PVC)      │  (2Gi PVC, 256MB maxmemory)     │
+├──────────────────┴──────────────────────────────────┤
+│  Monitoring: Prometheus (10Gi) + Grafana (5Gi)      │
+└─────────────────────────────────────────────────────┘
+```
+
+## 서비스 간 통신 흐름
+
+| 소스 | 대상 | 프로토콜 | K8s DNS |
+|------|------|----------|---------|
+| Ingress | frontend | HTTP | frontend.agentforge.svc.cluster.local:3000 |
+| Ingress | backend | HTTP/WS | backend.agentforge.svc.cluster.local:8000 |
+| backend | PostgreSQL | TCP | postgres-0.postgres.agentforge.svc.cluster.local:5432 |
+| backend | Redis | TCP | redis-0.redis.agentforge.svc.cluster.local:6379 |
+| backend | data-collector | HTTP | data-collector.agentforge.svc.cluster.local:8001 |
+| data-collector | PostgreSQL | TCP | (동일) |
+| data-collector | Redis | TCP | (동일) |
+| Prometheus | backend | HTTP | /metrics 스크래핑 |
+| Prometheus | data-collector | HTTP | /metrics 스크래핑 |
+
+## 환경변수 매핑 (docker-compose → K8s)
+
+### ConfigMap (비민감)
+
+| 환경변수 | docker-compose | K8s ConfigMap |
+|----------|---------------|---------------|
+| POSTGRES_DB | `${POSTGRES_DB:?...}` | `agentforge` |
+| DATA_COLLECTOR_URL | `http://data-collector:8001` | `http://data-collector.agentforge.svc.cluster.local:8001` |
+| CORS_ORIGINS | `.env` | `["https://your-domain.com"]` |
+| DEBUG | `false` | `false` |
+| DAILY_COST_LIMIT | `.env` | `10.0` |
+| AUTH_RATE_LIMIT | `.env` | `5` |
+| DB_POOL_SIZE | (기본값 5) | `5` |
+| DB_MAX_OVERFLOW | (기본값 10) | `10` |
+
+### Secret (민감)
+
+| 환경변수 | docker-compose | K8s Secret |
+|----------|---------------|-----------|
+| SECRET_KEY | `.env` | agentforge-secrets |
+| ENCRYPTION_KEY | `.env` | agentforge-secrets |
+| DATABASE_URL | `.env` + env override | agentforge-secrets |
+| REDIS_URL | env override | agentforge-secrets |
+| POSTGRES_USER | `${POSTGRES_USER:?...}` | agentforge-secrets |
+| POSTGRES_PASSWORD | `${POSTGRES_PASSWORD:?...}` | agentforge-secrets |
+| REDIS_PASSWORD | `${REDIS_PASSWORD:?...}` | agentforge-secrets |
+
+## 주요 설계 결정
+
+### 1. gunicorn workers=1 (Architect #2)
+
+WebSocket ConnectionManager가 in-memory dict 기반이므로 workers > 1이면 세션이 분산되어 메시지 유실. workers=1 + HPA 수평 확장으로 보상.
+
+**향후 개선**: Redis Pub/Sub로 WS 메시지 브로드캐스트 → workers=4 복원 가능.
+
+### 2. Alembic Job 분리 (Architect #1)
+
+initContainer 대신 별도 Job으로 분리하여 race condition 방지. 여러 pod가 동시에 마이그레이션을 실행하면 충돌 가능.
+
+**배포 순서**: PostgreSQL Ready → Migration Job 완료 → Backend Deployment.
+
+### 3. Cookie Affinity (Critic A2)
+
+Ingress 뒤에서 ClientIP affinity는 Ingress 자체 IP로 인식되어 무효. Cookie 기반 affinity로 WebSocket 세션 유지.
+
+### 4. NetworkPolicy (Critic A4)
+
+최소 권한 원칙 적용:
+- PostgreSQL: backend + data-collector + migration-job만 접근
+- Redis: backend + data-collector만 접근
+- 외부 트래픽: frontend + backend만 허용
+
+### 5. PodDisruptionBudget (Architect #7)
+
+backend, frontend에 PDB 적용 (minAvailable: 1). 롤링 업데이트/노드 드레인 시 서비스 가용성 보장.
+
+## WebSocket 스케일링 전략
+
+| 단계 | 방식 | 처리량 | 제한 |
+|------|------|--------|------|
+| **현재** | workers=1 + HPA (2-5 pods) | 중간 | pod간 WS 세션 격리 |
+| **향후** | workers=4 + Redis Pub/Sub | 높음 | Redis 의존성 추가 |
+
+현재 구조에서 cookie affinity로 같은 사용자의 WS 연결이 동일 pod로 라우팅되어 실용적으로 동작.
+
+## 코드 수정 사항
+
+| 파일 | 변경 | 이유 |
+|------|------|------|
+| `backend/shared/config.py` | DB_POOL_SIZE, DB_MAX_OVERFLOW 추가 | K8s 환경변수로 풀 크기 조정 |
+| `backend/shared/database.py` | pool_size, max_overflow, pool_recycle, pool_pre_ping | 커넥션 풀 최적화 |
+| `docker/Dockerfile.backend.prod` | workers=1, --ws-max-size | WS 호환 + 메시지 크기 제한 |
+| `docker/Dockerfile.collector.prod` | HEALTHCHECK /api/v1/health | 실제 엔드포인트와 일치 |
+
+## 파일 구조
+
+```
+k8s/
+├── kustomization.yaml          # Kustomize 진입점
+├── namespace.yaml              # agentforge 네임스페이스
+├── configmap.yaml              # 비민감 환경변수
+├── secrets.yaml.example        # 민감 환경변수 (템플릿)
+├── ingress.yaml                # NGINX Ingress + cookie affinity
+├── network-policy.yaml         # Pod간 접근 제어
+├── backend/
+│   ├── migration-job.yaml      # Alembic DB 마이그레이션
+│   ├── deployment.yaml         # 2 replicas, HPA 대상
+│   ├── service.yaml            # ClusterIP :8000
+│   ├── hpa.yaml                # CPU 70%, 2-5 replicas
+│   └── pdb.yaml                # minAvailable: 1
+├── frontend/
+│   ├── deployment.yaml         # 2 replicas
+│   ├── service.yaml            # ClusterIP :3000
+│   └── pdb.yaml                # minAvailable: 1
+├── data-collector/
+│   ├── deployment.yaml         # 1 replica
+│   └── service.yaml            # ClusterIP :8001
+├── postgres/
+│   ├── statefulset.yaml        # 1 replica, 10Gi PVC
+│   └── service.yaml            # Headless
+├── redis/
+│   ├── statefulset.yaml        # 1 replica, 2Gi PVC
+│   └── service.yaml            # Headless
+└── monitoring/
+    ├── monitoring-secret.yaml.example
+    ├── prometheus-configmap.yaml
+    ├── prometheus-deployment.yaml  # + PVC 10Gi
+    ├── prometheus-service.yaml
+    ├── grafana-deployment.yaml     # + PVC 5Gi + provisioning
+    └── grafana-service.yaml
+```
+
+## 알려진 제한사항
+
+1. **Grafana 대시보드 JSON**: ConfigMap으로 마운트하려면 `agentforge.json`을 별도 ConfigMap으로 생성해야 함 (크기가 커서 별도 관리 권장)
+2. **TLS**: cert-manager 설정은 클러스터별로 다르므로 주석 처리 상태
+3. **이미지 레지스트리**: `imagePullPolicy: Always` 미설정 — 프라이빗 레지스트리 사용 시 추가 설정 필요
+4. **Secrets**: `$(POSTGRES_USER)` 등 변수 참조는 K8s에서 자동 치환되지 않음 — 실제 배포 시 직접 연결 문자열 입력 필요

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,136 @@
+# AgentForge Kubernetes Deployment
+
+Docker Compose 기반 AgentForge를 Kubernetes 클러스터에 배포하기 위한 매니페스트입니다.
+
+## 사전 요구사항
+
+- `kubectl` CLI (v1.28+)
+- Kubernetes 클러스터 (v1.28+)
+- NGINX Ingress Controller (`kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml`)
+- Container 이미지 빌드 완료 (agentforge-backend, agentforge-frontend, agentforge-collector)
+
+## 이미지 빌드
+
+```bash
+# Backend
+docker build -f docker/Dockerfile.backend.prod -t agentforge-backend:latest ./backend
+
+# Frontend
+docker build -f docker/Dockerfile.frontend.prod \
+  --build-arg NEXT_PUBLIC_API_URL=https://your-domain.com/api \
+  --build-arg NEXT_PUBLIC_WS_URL=wss://your-domain.com/ws \
+  -t agentforge-frontend:latest ./frontend
+
+# Data Collector
+docker build -f docker/Dockerfile.collector.prod -t agentforge-collector:latest ./data-collector
+```
+
+## 시크릿 생성
+
+```bash
+# 1. 시크릿 파일 복사
+cp k8s/secrets.yaml.example k8s/secrets.yaml
+cp k8s/monitoring/monitoring-secret.yaml.example k8s/monitoring/monitoring-secret.yaml
+
+# 2. base64 인코딩된 값으로 교체
+echo -n 'your-secret-key' | base64
+# 출력된 값을 secrets.yaml에 붙여넣기
+
+# 3. 시크릿 적용
+kubectl apply -f k8s/secrets.yaml
+kubectl apply -f k8s/monitoring/monitoring-secret.yaml
+```
+
+## 배포 순서
+
+```bash
+# 1. 네임스페이스 + 시크릿 (먼저 적용)
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/secrets.yaml
+kubectl apply -f k8s/monitoring/monitoring-secret.yaml
+
+# 2. 전체 매니페스트 배포 (kustomize)
+kubectl apply -k k8s/
+
+# 3. PostgreSQL 준비 대기
+kubectl wait --for=condition=ready pod/postgres-0 -n agentforge --timeout=120s
+
+# 4. DB 마이그레이션 Job 완료 대기
+kubectl wait --for=condition=complete job/alembic-migration -n agentforge --timeout=120s
+
+# 5. 전체 서비스 상태 확인
+kubectl get pods -n agentforge
+kubectl get jobs -n agentforge
+kubectl get svc -n agentforge
+```
+
+## 스케일링
+
+```bash
+# 수동 스케일링
+kubectl scale deployment backend -n agentforge --replicas=3
+
+# HPA 확인 (backend은 자동 스케일링)
+kubectl get hpa -n agentforge
+
+# HPA 상세 정보
+kubectl describe hpa backend-hpa -n agentforge
+```
+
+## 트러블슈팅
+
+```bash
+# Pod 로그 확인
+kubectl logs -f deployment/backend -n agentforge
+kubectl logs -f deployment/frontend -n agentforge
+kubectl logs -f deployment/data-collector -n agentforge
+
+# Pod 상태 확인
+kubectl describe pod <pod-name> -n agentforge
+
+# 마이그레이션 Job 로그
+kubectl logs job/alembic-migration -n agentforge
+
+# 서비스 연결 테스트
+kubectl run debug --rm -it --image=busybox -n agentforge -- wget -qO- http://backend:8000/api/v1/health
+
+# Ingress 상태
+kubectl describe ingress agentforge-ingress -n agentforge
+```
+
+## 로컬 테스트 (minikube)
+
+```bash
+# minikube 시작
+minikube start
+
+# Ingress addon 활성화
+minikube addons enable ingress
+
+# 이미지 빌드 (minikube Docker 환경 사용)
+eval $(minikube docker-env)
+docker build -f docker/Dockerfile.backend.prod -t agentforge-backend:latest ./backend
+docker build -f docker/Dockerfile.frontend.prod \
+  --build-arg NEXT_PUBLIC_API_URL=http://localhost/api \
+  --build-arg NEXT_PUBLIC_WS_URL=ws://localhost/ws \
+  -t agentforge-frontend:latest ./frontend
+docker build -f docker/Dockerfile.collector.prod -t agentforge-collector:latest ./data-collector
+
+# 시크릿 생성 후 배포
+cp k8s/secrets.yaml.example k8s/secrets.yaml
+# secrets.yaml 값 설정...
+kubectl apply -f k8s/secrets.yaml
+kubectl apply -k k8s/
+
+# 접속 (minikube tunnel 필요)
+minikube tunnel
+```
+
+## 관리형 서비스 전환 가이드
+
+프로덕션 환경에서 관리형 DB/Redis 사용 시:
+
+1. `k8s/postgres/`, `k8s/redis/` 디렉토리 삭제
+2. `kustomization.yaml`에서 해당 리소스 제거
+3. `secrets.yaml`의 DATABASE_URL, REDIS_URL을 관리형 서비스 엔드포인트로 변경
+4. NetworkPolicy에서 postgres/redis 관련 정책 제거

--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: agentforge
+  labels:
+    app: backend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: agentforge-backend:latest
+          ports:
+            - containerPort: 8000
+              name: http
+          envFrom:
+            - configMapRef:
+                name: agentforge-config
+            - secretRef:
+                name: agentforge-secrets
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/k8s/backend/hpa.yaml
+++ b/k8s/backend/hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-hpa
+  namespace: agentforge
+  labels:
+    app: backend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/backend/migration-job.yaml
+++ b/k8s/backend/migration-job.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: migration
 spec:
   backoffLimit: 3
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:

--- a/k8s/backend/migration-job.yaml
+++ b/k8s/backend/migration-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alembic-migration
+  namespace: agentforge
+  labels:
+    app: backend
+    app.kubernetes.io/part-of: agentforge
+    app.kubernetes.io/component: migration
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: backend
+        component: migration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migration
+          image: agentforge-backend:latest
+          command: ["sh", "-c", "cd /app/backend && alembic upgrade head"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: agentforge-secrets
+                  key: DATABASE_URL

--- a/k8s/backend/pdb.yaml
+++ b/k8s/backend/pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-pdb
+  namespace: agentforge
+  labels:
+    app: backend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: backend

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: agentforge
+  labels:
+    app: backend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentforge-config
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+data:
+  POSTGRES_DB: "agentforge"
+  DATA_COLLECTOR_URL: "http://data-collector.agentforge.svc.cluster.local:8001"
+  CORS_ORIGINS: '["https://your-domain.com"]'
+  DEBUG: "false"
+  DAILY_COST_LIMIT: "10.0"
+  AUTH_RATE_LIMIT: "5"
+  DB_POOL_SIZE: "5"
+  DB_MAX_OVERFLOW: "10"

--- a/k8s/data-collector/deployment.yaml
+++ b/k8s/data-collector/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-collector
+  namespace: agentforge
+  labels:
+    app: data-collector
+    app.kubernetes.io/part-of: agentforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: data-collector
+  template:
+    metadata:
+      labels:
+        app: data-collector
+    spec:
+      containers:
+        - name: data-collector
+          image: agentforge-collector:latest
+          ports:
+            - containerPort: 8001
+              name: http
+          envFrom:
+            - configMapRef:
+                name: agentforge-config
+            - secretRef:
+                name: agentforge-secrets
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8001
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/k8s/data-collector/service.yaml
+++ b/k8s/data-collector/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-collector
+  namespace: agentforge
+  labels:
+    app: data-collector
+    app.kubernetes.io/part-of: agentforge
+spec:
+  type: ClusterIP
+  selector:
+    app: data-collector
+  ports:
+    - port: 8001
+      targetPort: 8001
+      name: http

--- a/k8s/frontend/deployment.yaml
+++ b/k8s/frontend/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: agentforge
+  labels:
+    app: frontend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: agentforge-frontend:latest
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/k8s/frontend/pdb.yaml
+++ b/k8s/frontend/pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend-pdb
+  namespace: agentforge
+  labels:
+    app: frontend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: frontend

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: agentforge
+  labels:
+    app: frontend
+    app.kubernetes.io/part-of: agentforge
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     # WebSocket support
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
-    nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
     # Cookie-based session affinity (Critic A2: ClientIP ineffective behind Ingress)
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "AGENTFORGE_AFFINITY"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agentforge-ingress
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    # WebSocket support
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
+    # Cookie-based session affinity (Critic A2: ClientIP ineffective behind Ingress)
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "AGENTFORGE_AFFINITY"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "10800"
+    # TLS (uncomment when cert-manager is configured)
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  # TLS (uncomment when certificate is ready)
+  # tls:
+  #   - hosts:
+  #       - your-domain.com
+  #     secretName: agentforge-tls
+  rules:
+    - host: your-domain.com
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /ws/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3000

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: agentforge
+
+resources:
+  # 1. Namespace
+  - namespace.yaml
+
+  # 2. Configuration
+  - configmap.yaml
+
+  # 3. Stateful services (PostgreSQL + Redis)
+  - postgres/statefulset.yaml
+  - postgres/service.yaml
+  - redis/statefulset.yaml
+  - redis/service.yaml
+
+  # 4. Database migration (run after PostgreSQL is ready)
+  - backend/migration-job.yaml
+
+  # 5. Stateless services
+  - backend/deployment.yaml
+  - backend/service.yaml
+  - backend/hpa.yaml
+  - backend/pdb.yaml
+  - frontend/deployment.yaml
+  - frontend/service.yaml
+  - frontend/pdb.yaml
+  - data-collector/deployment.yaml
+  - data-collector/service.yaml
+
+  # 6. Networking
+  - ingress.yaml
+  - network-policy.yaml
+
+  # 7. Monitoring
+  - monitoring/prometheus-configmap.yaml
+  - monitoring/prometheus-deployment.yaml
+  - monitoring/prometheus-service.yaml
+  - monitoring/grafana-deployment.yaml
+  - monitoring/grafana-service.yaml
+
+# Note: Secrets are NOT included in kustomization.yaml.
+# They must be applied manually:
+#   kubectl apply -f k8s/secrets.yaml
+#   kubectl apply -f k8s/monitoring/monitoring-secret.yaml

--- a/k8s/monitoring/grafana-deployment.yaml
+++ b/k8s/monitoring/grafana-deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.0
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: monitoring-secrets
+                  key: GF_SECURITY_ADMIN_USER
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: monitoring-secrets
+                  key: GF_SECURITY_ADMIN_PASSWORD
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          volumeMounts:
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+            - name: grafana-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: grafana-dashboards-config
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: grafana-dashboards
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: grafana-data
+          persistentVolumeClaim:
+            claimName: grafana-data
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
+        - name: grafana-dashboards-config
+          configMap:
+            name: grafana-dashboards-config
+        - name: grafana-dashboards
+          configMap:
+            name: grafana-dashboard-agentforge
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+data:
+  datasource.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.agentforge.svc.cluster.local:9090
+        isDefault: true
+        editable: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-config
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+data:
+  dashboard.yml: |
+    apiVersion: 1
+    providers:
+      - name: 'AgentForge'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false

--- a/k8s/monitoring/grafana-deployment.yaml
+++ b/k8s/monitoring/grafana-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: grafana
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        fsGroup: 472
       containers:
         - name: grafana
           image: grafana/grafana:10.4.0

--- a/k8s/monitoring/grafana-service.yaml
+++ b/k8s/monitoring/grafana-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+spec:
+  type: ClusterIP
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http

--- a/k8s/monitoring/monitoring-secret.yaml.example
+++ b/k8s/monitoring/monitoring-secret.yaml.example
@@ -1,0 +1,16 @@
+# Grafana monitoring secrets
+# Usage:
+#   1. Copy: cp monitoring-secret.yaml.example monitoring-secret.yaml
+#   2. Replace <BASE64_ENCODED_VALUE> with base64-encoded values
+#   3. Apply: kubectl apply -f monitoring-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitoring-secrets
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+type: Opaque
+data:
+  GF_SECURITY_ADMIN_USER: <BASE64_ENCODED_VALUE>
+  GF_SECURITY_ADMIN_PASSWORD: <BASE64_ENCODED_VALUE>

--- a/k8s/monitoring/prometheus-configmap.yaml
+++ b/k8s/monitoring/prometheus-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: agentforge
+  labels:
+    app: prometheus
+    app.kubernetes.io/part-of: agentforge
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: 'backend'
+        metrics_path: '/metrics'
+        static_configs:
+          - targets: ['backend.agentforge.svc.cluster.local:8000']
+            labels:
+              service: 'backend'
+
+      - job_name: 'data-collector'
+        metrics_path: '/metrics'
+        static_configs:
+          - targets: ['data-collector.agentforge.svc.cluster.local:8001']
+            labels:
+              service: 'data-collector'

--- a/k8s/monitoring/prometheus-deployment.yaml
+++ b/k8s/monitoring/prometheus-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: agentforge
+  labels:
+    app: prometheus
+    app.kubernetes.io/part-of: agentforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.51.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=15d"
+          ports:
+            - containerPort: 9090
+              name: http
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+            - name: prometheus-data
+              mountPath: /prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-data
+          persistentVolumeClaim:
+            claimName: prometheus-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: agentforge
+  labels:
+    app: prometheus
+    app.kubernetes.io/part-of: agentforge
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/monitoring/prometheus-deployment.yaml
+++ b/k8s/monitoring/prometheus-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: prometheus
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
       containers:
         - name: prometheus
           image: prom/prometheus:v2.51.0

--- a/k8s/monitoring/prometheus-service.yaml
+++ b/k8s/monitoring/prometheus-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: agentforge
+  labels:
+    app: prometheus
+    app.kubernetes.io/part-of: agentforge
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+      name: http

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentforge
+  labels:
+    app.kubernetes.io/name: agentforge
+    app.kubernetes.io/part-of: agentforge

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,80 @@
+# NetworkPolicy: Restrict access to PostgreSQL
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-access
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+        - podSelector:
+            matchLabels:
+              app: data-collector
+        - podSelector:
+            matchLabels:
+              component: migration
+      ports:
+        - protocol: TCP
+          port: 5432
+---
+# NetworkPolicy: Restrict access to Redis
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-access
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+        - podSelector:
+            matchLabels:
+              app: data-collector
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+# NetworkPolicy: Allow Ingress traffic only to frontend and backend
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-access
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - frontend
+          - backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from: []
+      ports:
+        - protocol: TCP
+          port: 3000
+        - protocol: TCP
+          port: 8000

--- a/k8s/postgres/service.yaml
+++ b/k8s/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: agentforge
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: agentforge
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgresql

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -49,18 +49,18 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - postgres
+                - sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -h localhost -p 5432
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - postgres
+                - sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -h localhost -p 5432
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: agentforge
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: agentforge
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: agentforge-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: agentforge-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: agentforge-secrets
+                  key: POSTGRES_PASSWORD
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/redis/service.yaml
+++ b/k8s/redis/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: agentforge
+  labels:
+    app: redis
+    app.kubernetes.io/part-of: agentforge
+spec:
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis

--- a/k8s/redis/statefulset.yaml
+++ b/k8s/redis/statefulset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: agentforge
+  labels:
+    app: redis
+    app.kubernetes.io/part-of: agentforge
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: agentforge-secrets
+                  key: REDIS_PASSWORD
+          command:
+            - sh
+            - -c
+            - redis-server --requirepass $(REDIS_PASSWORD) --maxmemory 256mb --maxmemory-policy allkeys-lru
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep -q PONG
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep -q PONG
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/redis/statefulset.yaml
+++ b/k8s/redis/statefulset.yaml
@@ -36,6 +36,7 @@ spec:
               echo "requirepass $REDIS_PASSWORD" > /tmp/redis.conf
               echo "maxmemory 256mb" >> /tmp/redis.conf
               echo "maxmemory-policy allkeys-lru" >> /tmp/redis.conf
+              chmod 600 /tmp/redis.conf
               redis-server /tmp/redis.conf
           resources:
             requests:

--- a/k8s/redis/statefulset.yaml
+++ b/k8s/redis/statefulset.yaml
@@ -32,7 +32,11 @@ spec:
           command:
             - sh
             - -c
-            - redis-server --requirepass $(REDIS_PASSWORD) --maxmemory 256mb --maxmemory-policy allkeys-lru
+            - |
+              echo "requirepass $REDIS_PASSWORD" > /tmp/redis.conf
+              echo "maxmemory 256mb" >> /tmp/redis.conf
+              echo "maxmemory-policy allkeys-lru" >> /tmp/redis.conf
+              redis-server /tmp/redis.conf
           resources:
             requests:
               memory: "64Mi"
@@ -45,7 +49,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli -a $REDIS_PASSWORD ping | grep -q PONG
+                - REDISCLI_AUTH=$REDIS_PASSWORD redis-cli ping | grep -q PONG
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
@@ -54,7 +58,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli -a $REDIS_PASSWORD ping | grep -q PONG
+                - REDISCLI_AUTH=$REDIS_PASSWORD redis-cli ping | grep -q PONG
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5

--- a/k8s/secrets.yaml.example
+++ b/k8s/secrets.yaml.example
@@ -1,0 +1,27 @@
+# K8s Secrets for AgentForge
+# Usage:
+#   1. Copy this file: cp secrets.yaml.example secrets.yaml
+#   2. Replace <BASE64_ENCODED_VALUE> with actual base64-encoded values:
+#      echo -n 'your-secret-value' | base64
+#   3. Apply: kubectl apply -f secrets.yaml
+#
+# WARNING: Never commit secrets.yaml to version control!
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentforge-secrets
+  namespace: agentforge
+  labels:
+    app.kubernetes.io/part-of: agentforge
+type: Opaque
+data:
+  SECRET_KEY: <BASE64_ENCODED_VALUE>
+  ENCRYPTION_KEY: <BASE64_ENCODED_VALUE>
+  POSTGRES_USER: <BASE64_ENCODED_VALUE>
+  POSTGRES_PASSWORD: <BASE64_ENCODED_VALUE>
+  REDIS_PASSWORD: <BASE64_ENCODED_VALUE>
+stringData:
+  # These use stringData for readability; K8s will base64-encode them automatically.
+  # Replace the placeholder values below with your actual connection strings.
+  DATABASE_URL: "postgresql+asyncpg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres-0.postgres.agentforge.svc.cluster.local:5432/agentforge"
+  REDIS_URL: "redis://:$(REDIS_PASSWORD)@redis-0.redis.agentforge.svc.cluster.local:6379"

--- a/k8s/secrets.yaml.example
+++ b/k8s/secrets.yaml.example
@@ -21,7 +21,8 @@ data:
   POSTGRES_PASSWORD: <BASE64_ENCODED_VALUE>
   REDIS_PASSWORD: <BASE64_ENCODED_VALUE>
 stringData:
-  # These use stringData for readability; K8s will base64-encode them automatically.
-  # Replace the placeholder values below with your actual connection strings.
-  DATABASE_URL: "postgresql+asyncpg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres-0.postgres.agentforge.svc.cluster.local:5432/agentforge"
-  REDIS_URL: "redis://:$(REDIS_PASSWORD)@redis-0.redis.agentforge.svc.cluster.local:6379"
+  # WARNING: K8s does NOT auto-substitute variable references in stringData.
+  # You MUST replace REPLACE_USER, REPLACE_PASSWORD with actual values.
+  # Example: postgresql+asyncpg://myuser:mypass@postgres-0.postgres.agentforge.svc.cluster.local:5432/agentforge
+  DATABASE_URL: "postgresql+asyncpg://REPLACE_USER:REPLACE_PASSWORD@postgres-0.postgres.agentforge.svc.cluster.local:5432/agentforge"
+  REDIS_URL: "redis://:REPLACE_REDIS_PASSWORD@redis-0.redis.agentforge.svc.cluster.local:6379"


### PR DESCRIPTION
## Summary
- Docker Compose 기반 7개 서비스를 Kubernetes에 배포하기 위한 매니페스트 + 코드 수정
- Architect 7 must-fix + Critic 6 추가 발견 전부 반영

## Changes

### 수정된 파일 (4개)
- `backend/shared/config.py` — DB_POOL_SIZE, DB_MAX_OVERFLOW 설정 추가
- `backend/shared/database.py` — pool_size, max_overflow, pool_recycle, pool_pre_ping 적용
- `docker/Dockerfile.backend.prod` — workers=1 (WS in-memory 호환) + --ws-max-size 추가
- `docker/Dockerfile.collector.prod` — HEALTHCHECK 경로 /health → /api/v1/health 수정
- `.gitignore` — k8s sensitive file exclusion 추가

### 새로 추가된 파일 (28개)
**K8s 기본 (Phase 10-2)**
- `k8s/namespace.yaml` — agentforge 네임스페이스
- `k8s/configmap.yaml` — 비민감 환경변수 (POSTGRES_DB, CORS_ORIGINS, DEBUG 등)
- `k8s/secrets.yaml.example` — 민감 환경변수 템플릿
- `k8s/monitoring/monitoring-secret.yaml.example` — Grafana 인증 템플릿

**StatefulSet (Phase 10-3)**
- `k8s/postgres/statefulset.yaml` — PostgreSQL 16-alpine, 10Gi PVC
- `k8s/postgres/service.yaml` — Headless Service
- `k8s/redis/statefulset.yaml` — Redis 7-alpine, 2Gi PVC, 256MB maxmemory
- `k8s/redis/service.yaml` — Headless Service

**Stateless (Phase 10-4)**
- `k8s/backend/migration-job.yaml` — Alembic Job (race condition safe)
- `k8s/backend/deployment.yaml` — 2 replicas, HPA 대상
- `k8s/backend/service.yaml` — ClusterIP :8000
- `k8s/backend/hpa.yaml` — CPU 70%, 2-5 replicas
- `k8s/backend/pdb.yaml` — PodDisruptionBudget minAvailable: 1
- `k8s/frontend/deployment.yaml` — 2 replicas
- `k8s/frontend/service.yaml` — ClusterIP :3000
- `k8s/frontend/pdb.yaml` — PodDisruptionBudget minAvailable: 1
- `k8s/data-collector/deployment.yaml` — 1 replica
- `k8s/data-collector/service.yaml` — ClusterIP :8001

**Networking + Monitoring (Phase 10-5)**
- `k8s/ingress.yaml` — NGINX Ingress, cookie affinity, WebSocket support
- `k8s/network-policy.yaml` — DB/Redis/Ingress 접근 제어 (3개 정책)
- `k8s/monitoring/prometheus-*.yaml` — Prometheus v2.51.0, 10Gi PVC
- `k8s/monitoring/grafana-*.yaml` — Grafana 10.4.0, 5Gi PVC, 프로비저닝

**Documentation (Phase 10-6)**
- `k8s/kustomization.yaml` — Kustomize 진입점 (18개 리소스)
- `k8s/README.md` — 배포 가이드
- `docs/sprint-10-k8s.md` — 아키텍처, 통신 흐름, 설계 결정

## Key Decisions
1. **gunicorn workers=1** — WebSocket ConnectionManager in-memory 호환. HPA로 수평 확장 보상.
2. **Alembic Job 분리** — initContainer 대신 별도 Job으로 race condition 방지
3. **Cookie Affinity** — Ingress 뒤 ClientIP 무효 → cookie 기반 WS 세션 유지
4. **NetworkPolicy** — 최소 권한 원칙 적용
5. **PDB** — 롤링 업데이트 시 backend/frontend 최소 1 pod 보장

## Ralplan 리뷰 반영
| # | 출처 | 심각도 | 반영 |
|---|------|--------|------|
| 1 | Architect | CRITICAL | Alembic Job 분리 ✅ |
| 2 | Architect | CRITICAL | workers=1 ✅ |
| 3 | Architect | HIGH | collector HEALTHCHECK 수정 ✅ |
| 4 | Architect | HIGH | .gitignore + .example 패턴 ✅ |
| 5 | Architect | HIGH | DATABASE_URL → Secret 이동 ✅ |
| 6 | Architect | MEDIUM | --ws-max-size 추가 ✅ |
| 7 | Architect | MEDIUM | PDB 추가 ✅ |
| A2 | Critic | HIGH | cookie affinity ✅ |
| A3 | Critic | MEDIUM | Grafana credential 정의 ✅ |
| A4 | Critic | MEDIUM | NetworkPolicy 추가 ✅ |
| A5 | Critic | MEDIUM | ConfigMap/Secret 완전 매핑 ✅ |
| A6 | Critic | LOW | 모니터링 리소스 limits ✅ |

## Verification
- [x] 백엔드 테스트: 676 passed, 9 skipped
- [x] Lint: ruff format + check 통과
- [x] .gitignore: 민감 파일 정상 무시 확인
- [x] 33 files changed, 1246 insertions(+)

Refs #85
