### PR TITLE
fix(k8s): grafana dashboard ConfigMap + NetworkPolicy tightening (#85)

### DIFF
--- a/k8s/monitoring/grafana-deployment.yaml
+++ b/k8s/monitoring/grafana-deployment.yaml
@@ -121,3 +121,112 @@ data:
         options:
           path: /var/lib/grafana/dashboards
           foldersFromFilesStructure: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-agentforge
+  namespace: agentforge
+  labels:
+    app: grafana
+    app.kubernetes.io/part-of: agentforge
+data:
+  agentforge.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "title": "HTTP Request Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(rate(http_requests_total[5m])) by (endpoint, status)", "legendFormat": "{{endpoint}} [{{status}}]" }],
+          "fieldConfig": { "defaults": { "unit": "reqps" } }
+        },
+        {
+          "title": "HTTP Latency (p50/p95/p99)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [
+            { "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p50" },
+            { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p95" },
+            { "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p99" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "title": "Error Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }],
+          "fieldConfig": { "defaults": { "unit": "reqps" } }
+        },
+        {
+          "title": "LLM Token Usage",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(rate(llm_tokens_total[5m])) by (provider, model, type)", "legendFormat": "{{provider}}/{{model}} [{{type}}]" }],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "title": "LLM Cost Tracking",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(llm_cost_dollars_total) by (model)", "legendFormat": "{{model}}" }],
+          "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+        },
+        {
+          "title": "LLM Request Latency",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_seconds_bucket[5m])) by (le, provider))", "legendFormat": "{{provider}} p95" }],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "title": "Pipeline Execution Status",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(rate(pipeline_executions_total[5m])) by (status)", "legendFormat": "{{status}}" }],
+          "fieldConfig": { "defaults": { "custom": { "stacking": { "mode": "normal" } } } }
+        },
+        {
+          "title": "Pipeline Duration Distribution",
+          "type": "histogram",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "sum(rate(pipeline_duration_seconds_bucket[5m])) by (le)", "legendFormat": "{{le}}", "format": "heatmap" }],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "title": "Active WebSocket Connections",
+          "type": "stat",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "targets": [{ "expr": "websocket_connections_active", "legendFormat": "Active" }],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["agentforge"],
+      "templating": {
+        "list": [{
+          "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+          "hide": 0, "includeAll": false, "name": "DS_PROMETHEUS",
+          "options": [], "query": "prometheus", "type": "datasource"
+        }]
+      },
+      "time": { "from": "now-1h", "to": "now" },
+      "title": "AgentForge Dashboard",
+      "uid": "agentforge-main"
+    }

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -72,7 +72,13 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from: []
+    - from:
+        # Allow traffic from ingress-nginx namespace
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        # Allow traffic from within agentforge namespace (inter-service)
+        - podSelector: {}
       ports:
         - protocol: TCP
           port: 3000


### PR DESCRIPTION
## Summary
Claude Review Critical/Warning 수정 - 릴리즈 PR #87 리뷰 피드백 반영.

## Changes
### 수정된 파일
- `k8s/monitoring/grafana-deployment.yaml` — grafana-dashboard-agentforge ConfigMap 추가 (기존 docker/grafana 대시보드 JSON 변환)
- `k8s/network-policy.yaml` — ingress-access 정책 from:[] → ingress-nginx namespace + agentforge namespace로 제한

## Key Decisions
- Grafana 대시보드는 기존 docker/grafana/provisioning/dashboards/agentforge.json을 그대로 ConfigMap으로 변환
- NetworkPolicy는 ingress-nginx namespace와 agentforge 내부 통신만 허용

## Verification
- [x] YAML 문법 확인

Refs #85
